### PR TITLE
Bump release template to use v0.40.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ on:
         description: Branch to target for version bump
 jobs:
   release:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v0.22.6
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v0.40.0
     with:
       release-ref: ${{ inputs.release-ref }}
       python-package: nemo_run


### PR DESCRIPTION
Bump release template to use v0.40.0

The old one was referencing another template at the old CI-Template repo location, so it would fail.