### PR TITLE
misc fixes

### DIFF
--- a/nemo_run/run/experiment.py
+++ b/nemo_run/run/experiment.py
@@ -302,6 +302,7 @@ nemo experiment cancel {exp_id} 0
         jobs: list[Job | JobGroup] | None = None,
         base_dir: str | None = None,
         clean_mode: bool = False,
+        enable_goodbye_message: bool = True,
     ) -> None:
         """
         Initializes an experiment run by creating its metadata directory and saving the experiment config.
@@ -317,6 +318,7 @@ nemo experiment cancel {exp_id} 0
             _reconstruct: Generally, the user does not need to specify this flag.
                 This is only set to True when using run.Experiment.from_dir.
             clean_mode: If True, disables all console output (logs, progress bars, etc.). Defaults to False.
+            enable_goodbye_message: if True, prints goodbye message after submitting job. Defaults to True.
         """
         configure_logging(level=log_level)
         self._reconstruct = _reconstruct
@@ -325,6 +327,7 @@ nemo experiment cancel {exp_id} 0
 
         self._title = title
         self._id = id or f"{title}_{int(time.time())}"
+        self._enable_goodbye_message = enable_goodbye_message
 
         base_dir = str(base_dir or get_nemorun_home())
         self._exp_dir = os.path.join(base_dir, "experiments", title, self._id)
@@ -1181,16 +1184,17 @@ For more information about `run.Config` and `run.Partial`, please refer to https
                         theme=os.environ.get("NEMO_RUN_CODE_THEME", "monokai"),
                     )
                 )
-                self.console.print(
-                    Syntax(
-                        self.GOODBYE_MESSAGE_BASH.format(
-                            exp_id=self._id,
-                            tasks=list(map(lambda job: job.id, self.jobs)),
-                        ),
-                        "shell",
-                        theme=os.environ.get("NEMO_RUN_CODE_THEME", "monokai"),
+                if self._enable_goodbye_message:
+                    self.console.print(
+                        Syntax(
+                            self.GOODBYE_MESSAGE_BASH.format(
+                                exp_id=self._id,
+                                tasks=list(map(lambda job: job.id, self.jobs)),
+                            ),
+                            "shell",
+                            theme=os.environ.get("NEMO_RUN_CODE_THEME", "monokai"),
+                        )
                     )
-                )
 
     def _repr_svg_(self):
         return self.to_config()._repr_svg_()

--- a/nemo_run/run/torchx_backend/packaging.py
+++ b/nemo_run/run/torchx_backend/packaging.py
@@ -138,7 +138,8 @@ def package(
             fn_or_script, serialize_configs=True
         )
         metadata = fn_or_script.metadata
-        env = env | fn_or_script.env
+        if fn_or_script.env:
+            env = env | fn_or_script.env
 
     launcher = executor.get_launcher()
     if executor.supports_launcher_transform():

--- a/nemo_run/run/torchx_backend/schedulers/slurm.py
+++ b/nemo_run/run/torchx_backend/schedulers/slurm.py
@@ -190,12 +190,6 @@ class SlurmTunnelScheduler(SchedulerMixin, SlurmScheduler):  # type: ignore
             cmd.append(f"--dependency={slurm_executor.dependency_type}:{':'.join(slurm_deps)}")
             req.launch_cmd = cmd
 
-        # Create the sbatch script if it does not exist
-        if not os.path.exists(dst_path):
-            os.makedirs(os.path.dirname(dst_path), exist_ok=True)
-            with open(dst_path, "w") as f:
-                f.write(str(req.materialize()))
-
         # Run sbatch script
         req.launch_cmd += [dst_path]
         job_id = self.tunnel.run(" ".join(req.launch_cmd)).stdout.strip()

--- a/nemo_run/run/torchx_backend/schedulers/slurm.py
+++ b/nemo_run/run/torchx_backend/schedulers/slurm.py
@@ -190,6 +190,12 @@ class SlurmTunnelScheduler(SchedulerMixin, SlurmScheduler):  # type: ignore
             cmd.append(f"--dependency={slurm_executor.dependency_type}:{':'.join(slurm_deps)}")
             req.launch_cmd = cmd
 
+        # Create the sbatch script if it does not exist
+        if not os.path.exists(dst_path):
+            os.makedirs(os.path.dirname(dst_path), exist_ok=True)
+            with open(dst_path, "w") as f:
+                f.write(req.materialize())
+
         # Run sbatch script
         req.launch_cmd += [dst_path]
         job_id = self.tunnel.run(" ".join(req.launch_cmd)).stdout.strip()

--- a/nemo_run/run/torchx_backend/schedulers/slurm.py
+++ b/nemo_run/run/torchx_backend/schedulers/slurm.py
@@ -194,7 +194,7 @@ class SlurmTunnelScheduler(SchedulerMixin, SlurmScheduler):  # type: ignore
         if not os.path.exists(dst_path):
             os.makedirs(os.path.dirname(dst_path), exist_ok=True)
             with open(dst_path, "w") as f:
-                f.write(req.materialize())
+                f.write(str(req.materialize()))
 
         # Run sbatch script
         req.launch_cmd += [dst_path]


### PR DESCRIPTION
Changes:
- [guard env appending if env is none](https://github.com/NVIDIA-NeMo/Run/pull/280/commits/3f865a336bc9f135231c361eb0f3e364ec01cdb7)
- [make goodbye message optional](https://github.com/NVIDIA-NeMo/Run/pull/280/commits/dda66eb88455b8198e835710fa436ca4bfa46e10)
- [write sbatch script if not already written](https://github.com/NVIDIA-NeMo/Run/pull/280/commits/97afe021b169817853b99855101054e8dd4d3f2e)

The main issue I faced was not getting the sbatch script written, i used something like the following code
```
    executor = run.SlurmExecutor(**slurm_config, tunnel=run.LocalTunnel(job_dir=job_dir))
    run_name = 'exp_name'
    with run.Experiment('exp', goodbye_message=False) as exp:
        exp.add(
            run.Script(
                path=script_path,
                args=[
                    "--config",
                    config_file,
                ],
                env=container_env,
                entrypoint="python",
            ),
            executor=executor,
            name=run_name[:37],  # DGX-C run name length limit
            tail_logs=False,
        )
        exp.run(sequential=True, detach=True, tail_logs=False)
```