### PR TITLE
Remove breaking torchrun config for single-node runs

### DIFF
--- a/nemo_run/core/execution/skypilot.py
+++ b/nemo_run/core/execution/skypilot.py
@@ -330,18 +330,6 @@ class SkypilotExecutor(Executor):
             het_group_host_var=self.HET_GROUP_HOST_VAR,
         )
 
-    def _setup_launcher(self):
-        super()._setup_launcher()
-        launcher = self.launcher
-        # Dynamic rendezvous has an error in Skypilot Kubernetes currently
-        if (
-            launcher
-            and isinstance(launcher, (Torchrun, FaultTolerance))
-            and self.cloud == "kubernetes"
-        ):
-            launcher.rdzv_backend = "static"
-            launcher.rdzv_port = 49500
-
     def to_task(
         self,
         name: str,

--- a/nemo_run/core/execution/skypilot.py
+++ b/nemo_run/core/execution/skypilot.py
@@ -27,7 +27,6 @@ from nemo_run.core.execution.base import (
     Executor,
     ExecutorMacros,
 )
-from nemo_run.core.execution.launcher import FaultTolerance, Torchrun
 from nemo_run.core.packaging.base import Packager
 from nemo_run.core.packaging.git import GitArchivePackager
 


### PR DESCRIPTION
I suspect there were upstream changes between now and when this code block was original written because it actually breaks single-node torchrun runs today. I tested this by overwritting this config change locally and my `launcher=torchrun` (on a single-node in k8s) started working. The error I was seeing originally was `[default7]:[I715 22:47:11.296780083 socket.cpp:872] [c10d] No socket on (localhost, 0) is listening yet, will retry.` for context, which led me to believe that rdzv backend was misconfigured, which finally led me to the overwritting of `c10d`.