### PR TITLE
Add reservation_config support to LeptonExecutor

### DIFF
--- a/nemo_run/core/execution/lepton.py
+++ b/nemo_run/core/execution/lepton.py
@@ -55,6 +55,7 @@ class LeptonExecutor(Executor):
     lepton_job_dir: str = field(init=False, default="")
     custom_spec: dict[str, Any] = field(default_factory=dict)
     pre_launch_commands: list[str] = field(default_factory=list)  # Custom commands before launch
+    reservation_config: Optional[dict[str, Any]] = None
 
     def stop_job(self, job_id: str):
         """
@@ -232,7 +233,7 @@ class LeptonExecutor(Executor):
             log=None,
             queue_config=None,
             stopped=None,
-            reservation_config=None,
+            reservation_config=self.reservation_config,
         )
         job = LeptonJob(spec=job_spec, metadata=Metadata(id=name))
 


### PR DESCRIPTION
- Add `reservation_config` field to `LeptonExecutor` dataclass
- Pass `reservation_config` from executor to job specification
- Enable users to configure reservation settings for Lepton jobs