### PR TITLE
Bump community-bot to 0.54.4

### DIFF
--- a/.github/workflows/community-bot.yml
+++ b/.github/workflows/community-bot.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   community-bot:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_community_bot.yml@v0.54.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_community_bot.yml@v0.54.4
     with:
       community_project_id: ${{ vars.COMMUNITY_PROJECT_ID }}
     secrets:


### PR DESCRIPTION
Bump community-bot to 0.54.4

Community users would be identified as those that are not part of the nvidia github orgs.