### PR TITLE
Create SkypilotJobsExecutor to allow running managed jobs

### DIFF
--- a/nemo_run/__init__.py
+++ b/nemo_run/__init__.py
@@ -29,6 +29,7 @@ from nemo_run.core.execution.lepton import LeptonExecutor
 from nemo_run.core.execution.local import LocalExecutor
 from nemo_run.core.execution.skypilot import SkypilotExecutor
 from nemo_run.core.execution.slurm import SlurmExecutor
+from nemo_run.core.execution.skypilot_jobs import SkypilotJobsExecutor
 from nemo_run.core.packaging import GitArchivePackager, HybridPackager, Packager, PatternPackager
 from nemo_run.core.tunnel.client import LocalTunnel, SSHTunnel
 from nemo_run.devspace.base import DevSpace
@@ -68,6 +69,7 @@ __all__ = [
     "run",
     "Script",
     "SkypilotExecutor",
+    "SkypilotJobsExecutor",
     "SlurmExecutor",
     "SSHTunnel",
     "Torchrun",

--- a/nemo_run/core/execution/skypilot_jobs.py
+++ b/nemo_run/core/execution/skypilot_jobs.py
@@ -1,0 +1,430 @@
+import logging
+import os
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Type, Union
+
+from invoke.context import Context
+
+from nemo_run.config import RUNDIR_NAME
+from nemo_run.core.execution.base import (
+    Executor,
+    ExecutorMacros,
+)
+from nemo_run.core.packaging.base import Packager
+from nemo_run.core.packaging.git import GitArchivePackager
+
+_SKYPILOT_AVAILABLE: bool = False
+try:
+    import sky
+    import sky.task as skyt
+    from sky import backends
+
+    _SKYPILOT_AVAILABLE = True
+except ImportError:
+    ...
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(kw_only=True)
+class SkypilotJobsExecutor(Executor):
+    """
+    Dataclass to configure a Skypilot Jobs Executor.
+
+    This executor launches managed jobs and requires the `Skypilot API Server <https://docs.skypilot.co/en/latest/reference/api-server/api-server.html>`.
+
+    Some familiarity with `Skypilot <https://skypilot.readthedocs.io/en/latest/docs/index.html>`_ is necessary.
+    In order to use this executor, you need to install NeMo Run
+    with either `skypilot` (for only Kubernetes) or `skypilot-all` (for all clouds) optional features.
+
+    Example:
+
+    .. code-block:: python
+
+        skypilot = SkypilotJobsExecutor(
+            gpus="A10G",
+            gpus_per_node=devices,
+            container_image="nvcr.io/nvidia/nemo:dev",
+            infra="k8s/my-context",
+            network_tier="best",
+            cluster_name="nemo_tester",
+            file_mounts={
+                "nemo_run.whl": "nemo_run.whl",
+                "/workspace/code": "/local/path/to/code",
+            },
+            storage_mounts={
+                "/workspace/outputs": {
+                    "name": "my-training-outputs",
+                    "store": "gcs",  # or "s3", "azure", etc.
+                    "mode": "MOUNT",
+                    "persistent": True,
+                },
+                "/workspace/checkpoints": {
+                    "name": "model-checkpoints",
+                    "store": "s3",
+                    "mode": "MOUNT",
+                    "persistent": True,
+                }
+            },
+            setup=\"\"\"
+        conda deactivate
+        nvidia-smi
+        ls -al ./
+        pip install nemo_run.whl
+        cd /opt/NeMo && git pull origin main && pip install .
+            \"\"\",
+        )
+
+    """
+
+    HEAD_NODE_IP_VAR = "head_node_ip"
+    NPROC_PER_NODE_VAR = "SKYPILOT_NUM_GPUS_PER_NODE"
+    NUM_NODES_VAR = "num_nodes"
+    NODE_RANK_VAR = "SKYPILOT_NODE_RANK"
+    HET_GROUP_HOST_VAR = "het_group_host"
+
+    container_image: Optional[str] = None
+    cloud: Optional[Union[str, list[str]]] = None
+    region: Optional[Union[str, list[str]]] = None
+    zone: Optional[Union[str, list[str]]] = None
+    gpus: Optional[Union[str, list[str]]] = None
+    gpus_per_node: Optional[int] = None
+    cpus: Optional[Union[int | float, list[int | float]]] = None
+    memory: Optional[Union[int | float, list[int | float]]] = None
+    instance_type: Optional[Union[str, list[str]]] = None
+    num_nodes: int = 1
+    use_spot: Optional[Union[bool, list[bool]]] = None
+    disk_size: Optional[Union[int, list[int]]] = None
+    disk_tier: Optional[Union[str, list[str]]] = None
+    ports: Optional[tuple[str]] = None
+    file_mounts: Optional[dict[str, str]] = None
+    storage_mounts: Optional[dict[str, dict[str, Any]]] = None  # Can be str or dict configs
+    cluster_name: Optional[str] = None
+    setup: Optional[str] = None
+    autodown: bool = False
+    idle_minutes_to_autostop: Optional[int] = None
+    torchrun_nproc_per_node: Optional[int] = None
+    cluster_config_overrides: Optional[dict[str, Any]] = None
+    infra: Optional[str] = None
+    network_tier: Optional[str] = None
+    retry_until_up: bool = False
+    packager: Packager = field(default_factory=lambda: GitArchivePackager())  # type: ignore  # noqa: F821
+
+    def __post_init__(self):
+        assert _SKYPILOT_AVAILABLE, (
+            'Skypilot is not installed. Please install it using `pip install "nemo_run[skypilot]"`.'
+        )
+        assert isinstance(self.packager, GitArchivePackager), (
+            "Only GitArchivePackager is currently supported for SkypilotExecutor."
+        )
+        if self.infra is not None:
+            assert self.cloud is None, "Cannot specify both `infra` and `cloud` parameters."
+            assert self.region is None, "Cannot specify both `infra` and `region` parameters."
+            assert self.zone is None, "Cannot specify both `infra` and `zone` parameters."
+            logger.info(
+                "`cloud` is deprecated and will be removed in a future version. Use `infra` instead."
+            )
+
+    @classmethod
+    def parse_app(cls: Type["SkypilotJobsExecutor"], app_id: str) -> tuple[str, str, int]:
+        app = app_id.split("___")
+        cluster, task, job_id = app[0], app[1], app[2]
+        assert cluster and task and job_id, f"Invalid app id for Skypilot: {app_id}"
+        return cluster, task, int(job_id)
+
+    def to_resources(self) -> Union[set["sky.Resources"], set["sky.Resources"]]:
+        from sky.resources import Resources
+
+        resources_cfg = {}
+        accelerators = None
+        if self.gpus:
+            if not self.gpus_per_node:
+                self.gpus_per_node = 1
+            else:
+                assert isinstance(self.gpus_per_node, int)
+
+            gpus = [self.gpus] if isinstance(self.gpus, str) else self.gpus
+
+            accelerators = {}
+            for gpu in gpus:
+                accelerators[gpu] = self.gpus_per_node
+
+            resources_cfg["accelerators"] = accelerators
+
+        if self.container_image:
+            resources_cfg["image_id"] = self.container_image
+
+        any_of = []
+
+        def parse_attr(attr: str):
+            if getattr(self, attr, None) is not None:
+                value = getattr(self, attr)
+                if isinstance(value, list):
+                    for i, val in enumerate(value):
+                        if len(any_of) < i + 1:
+                            any_of.append({})
+
+                        if isinstance(val, str) and val.lower() == "none":
+                            any_of[i][attr] = None
+                        else:
+                            any_of[i][attr] = val
+                else:
+                    if isinstance(value, str) and value.lower() == "none":
+                        resources_cfg[attr] = None
+                    else:
+                        resources_cfg[attr] = value
+
+        # any_of = False
+        attrs = [
+            "cloud",
+            "region",
+            "zone",
+            "cpus",
+            "memory",
+            "instance_type",
+            "use_spot",
+            "infra",
+            "network_tier",
+            "image_id",
+            "disk_size",
+            "disk_tier",
+            "ports",
+        ]
+
+        for attr in attrs:
+            parse_attr(attr)
+
+        resources_cfg["any_of"] = any_of
+        if self.cluster_config_overrides:
+            resources_cfg["_cluster_config_overrides"] = self.cluster_config_overrides
+
+        resources = Resources.from_yaml_config(resources_cfg)
+
+        return resources  # type: ignore
+
+    @classmethod
+    def status(
+        cls: Type["SkypilotJobsExecutor"], app_id: str
+    ) -> Optional[dict]:
+        from sky import stream_and_get
+        import sky.exceptions as sky_exceptions
+        import sky.jobs.client.sdk as sky_jobs
+
+        _, _, job_id = cls.parse_app(app_id)
+
+        try:
+            job_details: List[Dict[str, Any]] = stream_and_get(
+                sky_jobs.queue(
+                    refresh=True,
+                    all_users=True,
+                    job_ids=[job_id]
+                ),
+            )[0]
+        except sky_exceptions.ClusterNotUpError:
+            return None
+
+        return job_details
+
+    @classmethod
+    def cancel(cls: Type["SkypilotJobsExecutor"], app_id: str):
+        from sky.jobs.client.sdk import cancel
+
+        _, _, job_id = cls.parse_app(app_id=app_id)
+        job_details = cls.status(app_id=app_id)
+        if not job_details:
+            return
+
+        cancel(job_ids=[job_id])
+
+    @classmethod
+    def logs(cls: Type["SkypilotJobsExecutor"], app_id: str, fallback_path: Optional[str]):
+        import sky.jobs.client.sdk as sky_jobs
+
+        _, _, job_id = cls.parse_app(app_id)
+        job_details = cls.status(app_id)
+
+        is_terminal = False
+        if job_details and job_details["status"]:
+            is_terminal = job_details["status"].is_terminal()
+        elif not job_details:
+            is_terminal = True
+        if fallback_path and is_terminal:
+            log_path = os.path.expanduser(os.path.join(fallback_path, "run.log"))
+            if os.path.isfile(log_path):
+                with open(os.path.expanduser(os.path.join(fallback_path, "run.log"))) as f:
+                    for line in f:
+                        print(line, end="", flush=True)
+
+                return
+
+        sky_jobs.tail_logs(job_id=job_id)
+
+    @property
+    def workdir(self) -> str:
+        return os.path.join(f"{self.job_dir}", "workdir")
+
+    def package_configs(self, *cfgs: tuple[str, str]) -> list[str]:
+        filenames = []
+        basepath = os.path.join(self.job_dir, "configs")
+        for name, cfg in cfgs:
+            filename = os.path.join(basepath, name)
+            os.makedirs(os.path.dirname(filename), exist_ok=True)
+            with open(filename, "w") as f:
+                f.write(cfg)
+
+            filenames.append(
+                os.path.join(
+                    "/",
+                    RUNDIR_NAME,
+                    "configs",
+                    name,
+                )
+            )
+
+        return filenames
+
+    def assign(
+        self,
+        exp_id: str,
+        exp_dir: str,
+        task_id: str,
+        task_dir: str,
+    ):
+        self.job_name = task_id
+        self.experiment_dir = exp_dir
+        self.job_dir = os.path.join(exp_dir, task_dir)
+        self.experiment_id = exp_id
+
+    def package(self, packager: Packager, job_name: str):
+        assert self.experiment_id, "Executor not assigned to an experiment."
+        if isinstance(packager, GitArchivePackager):
+            output = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                check=True,
+                stdout=subprocess.PIPE,
+            )
+            path = output.stdout.splitlines()[0].decode()
+            base_path = Path(path).absolute()
+        else:
+            base_path = Path(os.getcwd()).absolute()
+
+        local_pkg = packager.package(base_path, self.job_dir, job_name)
+        local_code_extraction_path = os.path.join(self.job_dir, "code")
+        ctx = Context()
+        ctx.run(f"mkdir -p {local_code_extraction_path}")
+
+        if self.get_launcher().nsys_profile:
+            remote_nsys_extraction_path = os.path.join(
+                self.job_dir, self.get_launcher().nsys_folder
+            )
+            ctx.run(f"mkdir -p {remote_nsys_extraction_path}")
+        if local_pkg:
+            ctx.run(
+                f"tar -xvzf {local_pkg} -C {local_code_extraction_path} --ignore-zeros", hide=True
+            )
+
+    def nnodes(self) -> int:
+        return self.num_nodes
+
+    def nproc_per_node(self) -> int:
+        if self.torchrun_nproc_per_node:
+            return self.torchrun_nproc_per_node
+
+        return self.gpus_per_node or 1
+
+    def macro_values(self) -> Optional[ExecutorMacros]:
+        return ExecutorMacros(
+            head_node_ip_var=self.HEAD_NODE_IP_VAR,
+            nproc_per_node_var=self.NPROC_PER_NODE_VAR,
+            num_nodes_var=self.NUM_NODES_VAR,
+            node_rank_var=self.NODE_RANK_VAR,
+            het_group_host_var=self.HET_GROUP_HOST_VAR,
+        )
+
+    def to_task(
+        self,
+        name: str,
+        cmd: Optional[list[str]] = None,
+        env_vars: Optional[dict[str, str]] = None,
+    ) -> "skyt.Task":
+        from sky.task import Task
+
+        run_cmd = None
+        if cmd:
+            run_cmd = f"""
+conda deactivate
+
+num_nodes=`echo "$SKYPILOT_NODE_IPS" | wc -l`
+echo "num_nodes=$num_nodes"
+
+head_node_ip=`echo "$SKYPILOT_NODE_IPS" | head -n1`
+echo "head_node_ip=$head_node_ip"
+
+cd /nemo_run/code
+
+{" ".join(cmd)}
+"""
+        task = Task(
+            name=name,
+            setup=self.setup if self.setup else "",
+            run=run_cmd,
+            envs=self.env_vars,
+            num_nodes=self.num_nodes,
+        )
+        # Handle regular file mounts
+        file_mounts = self.file_mounts or {}
+        file_mounts["/nemo_run"] = self.job_dir
+        task.set_file_mounts(file_mounts)
+
+        # Handle storage mounts separately
+        if self.storage_mounts:
+            from sky.data import Storage
+
+            storage_objects = {}
+            for mount_path, config in self.storage_mounts.items():
+                # Create Storage object from config dict
+                storage_obj = Storage.from_yaml_config(config)
+                storage_objects[mount_path] = storage_obj
+            task.set_storage_mounts(storage_objects)
+
+        task.set_resources(self.to_resources())
+
+        if env_vars:
+            task.update_envs(env_vars)
+
+        return task
+
+    def launch(
+        self,
+        task: "skyt.Task",
+        num_nodes: Optional[int] = None,
+    ) -> tuple[Optional[int], Optional["backends.ResourceHandle"]]:
+        from sky import stream_and_get, skypilot_config
+        from sky.jobs.client.sdk import launch
+
+        if num_nodes:
+            task.num_nodes = num_nodes
+
+        job_id, handle = stream_and_get(
+            launch(task)
+        )
+
+        return job_id, handle
+
+    def cleanup(self, handle: str):
+        import sky.jobs.client.sdk as sky_jobs
+
+        _, _, path_str = handle.partition("://")
+        path = path_str.split("/")
+        app_id = path[1]
+
+        _, _, job_id = self.parse_app(app_id)
+        sky_jobs.download_logs(
+            name=None,
+            job_id=job_id,
+            refresh=True,
+            controller=True,
+            local_dir=self.job_dir,
+        )

--- a/nemo_run/core/execution/skypilot_jobs.py
+++ b/nemo_run/core/execution/skypilot_jobs.py
@@ -23,6 +23,7 @@ try:
 
     _SKYPILOT_AVAILABLE = True
 except ImportError:
+    # suppress import error so we don't crash if skypilot is not installed.
     pass
 
 logger = logging.getLogger(__name__)

--- a/nemo_run/core/execution/skypilot_jobs.py
+++ b/nemo_run/core/execution/skypilot_jobs.py
@@ -23,7 +23,7 @@ try:
 
     _SKYPILOT_AVAILABLE = True
 except ImportError:
-    ...
+    pass
 
 logger = logging.getLogger(__name__)
 
@@ -110,7 +110,7 @@ class SkypilotJobsExecutor(Executor):
     infra: Optional[str] = None
     network_tier: Optional[str] = None
     retry_until_up: bool = False
-    packager: Packager = field(default_factory=lambda: GitArchivePackager())  # type: ignore  # noqa: F821
+    packager: Packager = field(default_factory=GitArchivePackager)  # type: ignore  # noqa: F821
 
     def __post_init__(self):
         assert _SKYPILOT_AVAILABLE, (
@@ -204,9 +204,7 @@ class SkypilotJobsExecutor(Executor):
         return resources  # type: ignore
 
     @classmethod
-    def status(
-        cls: Type["SkypilotJobsExecutor"], app_id: str
-    ) -> Optional[dict]:
+    def status(cls: Type["SkypilotJobsExecutor"], app_id: str) -> Optional[dict]:
         from sky import stream_and_get
         import sky.exceptions as sky_exceptions
         import sky.jobs.client.sdk as sky_jobs
@@ -215,11 +213,7 @@ class SkypilotJobsExecutor(Executor):
 
         try:
             job_details: List[Dict[str, Any]] = stream_and_get(
-                sky_jobs.queue(
-                    refresh=True,
-                    all_users=True,
-                    job_ids=[job_id]
-                ),
+                sky_jobs.queue(refresh=True, all_users=True, job_ids=[job_id]),
             )[0]
         except sky_exceptions.ClusterNotUpError:
             return None
@@ -400,15 +394,13 @@ cd /nemo_run/code
         task: "skyt.Task",
         num_nodes: Optional[int] = None,
     ) -> tuple[Optional[int], Optional["backends.ResourceHandle"]]:
-        from sky import stream_and_get, skypilot_config
+        from sky import stream_and_get
         from sky.jobs.client.sdk import launch
 
         if num_nodes:
             task.num_nodes = num_nodes
 
-        job_id, handle = stream_and_get(
-            launch(task)
-        )
+        job_id, handle = stream_and_get(launch(task))
 
         return job_id, handle
 

--- a/nemo_run/core/execution/skypilot_jobs.py
+++ b/nemo_run/core/execution/skypilot_jobs.py
@@ -100,7 +100,7 @@ class SkypilotJobsExecutor(Executor):
     disk_tier: Optional[Union[str, list[str]]] = None
     ports: Optional[tuple[str]] = None
     file_mounts: Optional[dict[str, str]] = None
-    storage_mounts: Optional[dict[str, dict[str, Any]]] = None  # Can be str or dict configs
+    storage_mounts: Optional[dict[str, dict[str, Any]]] = None
     cluster_name: Optional[str] = None
     setup: Optional[str] = None
     autodown: bool = False
@@ -176,7 +176,6 @@ class SkypilotJobsExecutor(Executor):
                     else:
                         resources_cfg[attr] = value
 
-        # any_of = False
         attrs = [
             "cloud",
             "region",

--- a/nemo_run/run/experiment.py
+++ b/nemo_run/run/experiment.py
@@ -56,6 +56,7 @@ from nemo_run.core.execution.lepton import LeptonExecutor
 from nemo_run.core.execution.local import LocalExecutor
 from nemo_run.core.execution.skypilot import SkypilotExecutor
 from nemo_run.core.execution.slurm import SlurmExecutor
+from nemo_run.core.execution.skypilot_jobs import SkypilotJobsExecutor
 from nemo_run.core.frontend.console.api import CONSOLE, configure_logging, deconfigure_logging
 from nemo_run.core.serialization.zlib_json import ZlibJSONSerializer
 from nemo_run.core.tunnel.client import SSHTunnel, Tunnel
@@ -201,6 +202,7 @@ nemo experiment cancel {exp_id} 0
         SlurmExecutor,
         LocalExecutor,
         SkypilotExecutor,
+        SkypilotJobsExecutor,
         DockerExecutor,
         DGXCloudExecutor,
         LeptonExecutor,
@@ -208,6 +210,7 @@ nemo experiment cancel {exp_id} 0
     _DETACH_SUPPORTED_EXECUTORS = (
         SlurmExecutor,
         SkypilotExecutor,
+        SkypilotJobsExecutor,
         DGXCloudExecutor,
         LeptonExecutor,
     )

--- a/nemo_run/run/torchx_backend/schedulers/api.py
+++ b/nemo_run/run/torchx_backend/schedulers/api.py
@@ -24,10 +24,12 @@ from nemo_run.core.execution.lepton import LeptonExecutor
 from nemo_run.core.execution.local import LocalExecutor
 from nemo_run.core.execution.skypilot import SkypilotExecutor
 from nemo_run.core.execution.slurm import SlurmExecutor
+from nemo_run.core.execution.skypilot_jobs import SkypilotJobsExecutor
 
 EXECUTOR_MAPPING: dict[Type[Executor], str] = {
     SlurmExecutor: "slurm_tunnel",
     SkypilotExecutor: "skypilot",
+    SkypilotJobsExecutor: "skypilot_jobs",
     LocalExecutor: "local_persistent",
     DockerExecutor: "docker_persistent",
     DGXCloudExecutor: "dgx_cloud",
@@ -37,6 +39,7 @@ EXECUTOR_MAPPING: dict[Type[Executor], str] = {
 REVERSE_EXECUTOR_MAPPING: dict[str, Type[Executor]] = {
     "slurm_tunnel": SlurmExecutor,
     "skypilot": SkypilotExecutor,
+    "skypilot_jobs": SkypilotJobsExecutor,
     "local_persistent": LocalExecutor,
     "docker_persistent": DockerExecutor,
     "dgx_cloud": DGXCloudExecutor,

--- a/nemo_run/run/torchx_backend/schedulers/skypilot_jobs.py
+++ b/nemo_run/run/torchx_backend/schedulers/skypilot_jobs.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import os
 import shutil
 import tempfile
@@ -57,9 +56,8 @@ try:
         ManagedJobStatus.FAILED_CONTROLLER: AppState.FAILED,
     }
 except ImportError:
-    ...
+    pass
 
-log: logging.Logger = logging.getLogger(__name__)
 SKYPILOT_JOB_DIRS = os.path.join(get_nemorun_home(), ".skypilot_jobs.json")
 
 
@@ -187,7 +185,8 @@ class SkypilotJobsScheduler(SchedulerMixin, Scheduler[dict[str, str]]):  # type:
     def _cancel_existing(self, app_id: str) -> None:
         SkypilotJobsExecutor.cancel(app_id=app_id)
 
-    def list(self) -> list[ListAppResponse]: ...
+    def list(self) -> list[ListAppResponse]:
+        pass
 
 
 def create_scheduler(session_name: str, **kwargs: Any) -> SkypilotJobsScheduler:

--- a/nemo_run/run/torchx_backend/schedulers/skypilot_jobs.py
+++ b/nemo_run/run/torchx_backend/schedulers/skypilot_jobs.py
@@ -1,8 +1,3 @@
-"""
-This file contains the Skypilot Job scheduler which can be used to run TorchX
-components using Skypilot Managed Jobs.
-"""
-
 import json
 import logging
 import os
@@ -76,7 +71,6 @@ class SkypilotJobsRequest:
 
 class SkypilotJobsScheduler(SchedulerMixin, Scheduler[dict[str, str]]):  # type: ignore
     def __init__(self, session_name: str) -> None:
-        # NOTE: make sure any new init options are supported in create_scheduler(...)
         super().__init__("skypilot_jobs", session_name)
         assert _SKYPILOT_AVAILABLE, (
             'Skypilot is not installed. Please install it using `pip install "nemo_run[skypilot]"`'

--- a/nemo_run/run/torchx_backend/schedulers/skypilot_jobs.py
+++ b/nemo_run/run/torchx_backend/schedulers/skypilot_jobs.py
@@ -1,0 +1,246 @@
+"""
+This file contains the Skypilot Job scheduler which can be used to run TorchX
+components using Skypilot Managed Jobs.
+"""
+
+import json
+import logging
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from torchx.schedulers.api import (
+    AppDryRunInfo,
+    DescribeAppResponse,
+    ListAppResponse,
+    Scheduler,
+)
+from torchx.specs import (
+    AppDef,
+    AppState,
+    ReplicaStatus,
+    Role,
+    RoleStatus,
+    runopts,
+)
+
+from nemo_run.config import get_nemorun_home
+from nemo_run.core.execution.base import Executor
+from nemo_run.core.execution.skypilot import _SKYPILOT_AVAILABLE
+from nemo_run.core.execution.skypilot_jobs import SkypilotJobsExecutor
+from nemo_run.run.torchx_backend.schedulers.api import SchedulerMixin
+
+try:
+    import fcntl
+
+    FCNTL_AVAILABLE = True
+except ModuleNotFoundError:
+    fcntl = None
+    FCNTL_AVAILABLE = False
+
+SKYPILOT_STATES = {}
+try:
+    import sky.task as skyt
+    from sky.jobs.state import ManagedJobStatus
+
+    SKYPILOT_STATES: dict[ManagedJobStatus, AppState] = {
+        ManagedJobStatus.PENDING: AppState.PENDING,
+        ManagedJobStatus.DEPRECATED_SUBMITTED: AppState.SUBMITTED,
+        ManagedJobStatus.STARTING: AppState.SUBMITTED,
+        ManagedJobStatus.RUNNING: AppState.RUNNING,
+        ManagedJobStatus.RECOVERING: AppState.RUNNING,
+        ManagedJobStatus.CANCELLING: AppState.CANCELLED,
+        ManagedJobStatus.SUCCEEDED: AppState.SUCCEEDED,
+        ManagedJobStatus.CANCELLED: AppState.CANCELLED,
+        ManagedJobStatus.FAILED: AppState.FAILED,
+        ManagedJobStatus.FAILED_SETUP: AppState.FAILED,
+        ManagedJobStatus.FAILED_PRECHECKS: AppState.FAILED,
+        ManagedJobStatus.FAILED_NO_RESOURCE: AppState.FAILED,
+        ManagedJobStatus.FAILED_CONTROLLER: AppState.FAILED,
+    }
+except ImportError:
+    ...
+
+log: logging.Logger = logging.getLogger(__name__)
+SKYPILOT_JOB_DIRS = os.path.join(get_nemorun_home(), ".skypilot_jobs.json")
+
+
+@dataclass
+class SkypilotJobsRequest:
+    task: "skyt.Task"
+    executor: SkypilotJobsExecutor
+
+
+class SkypilotJobsScheduler(SchedulerMixin, Scheduler[dict[str, str]]):  # type: ignore
+    def __init__(self, session_name: str) -> None:
+        # NOTE: make sure any new init options are supported in create_scheduler(...)
+        super().__init__("skypilot_jobs", session_name)
+        assert _SKYPILOT_AVAILABLE, (
+            'Skypilot is not installed. Please install it using `pip install "nemo_run[skypilot]"`'
+        )
+
+    def _run_opts(self) -> runopts:
+        opts = runopts()
+        opts.add(
+            "job_dir",
+            type_=str,
+            help="""The directory to place the job code and outputs. The
+            directory must not exist and will be created.
+            """,
+        )
+        return opts
+
+    def schedule(self, dryrun_info: AppDryRunInfo[SkypilotJobsRequest]) -> str:
+        req = dryrun_info.request
+        task = req.task
+
+        executor = req.executor
+        executor.package(executor.packager, job_name=executor.job_name)
+        job_id, handle = executor.launch(task)
+        assert job_id and handle, (
+            f"Failed scheduling run on Skypilot. Job id: {job_id}, Handle: {handle}"
+        )
+        app_id = f"{handle.get_cluster_name()}___{task.name}___{job_id}"
+        task_details = SkypilotJobsExecutor.status(app_id=app_id)
+        if task_details:
+            _save_job_dir(
+                app_id,
+                job_status=task_details["status"].value,
+            )
+
+        return app_id
+
+    def _submit_dryrun(  # type: ignore
+        self, app: AppDef, cfg: Executor
+    ) -> AppDryRunInfo[SkypilotJobsRequest]:
+        from sky.utils import common_utils
+
+        assert isinstance(cfg, SkypilotJobsExecutor), (
+            f"{cfg.__class__} not supported for skypilot jobs scheduler."
+        )
+        executor = cfg
+
+        assert len(app.roles) == 1, "Only 1 role supported for Skypilot jobs executor."
+        role = app.roles[0]
+        values = executor.macro_values()
+        if values:
+            role = values.apply(role)
+
+        cmd = [role.entrypoint] + role.args
+        task = cfg.to_task(name=role.name, cmd=cmd, env_vars=role.env)
+
+        req = SkypilotJobsRequest(task=task, executor=cfg)
+        return AppDryRunInfo(req, lambda req: common_utils.dump_yaml_str(req.task.to_yaml_config()))
+
+    def _validate(self, app: AppDef, scheduler: str) -> None:
+        # Skip validation step for skypilot
+        pass
+
+    def describe(self, app_id: str) -> Optional[DescribeAppResponse]:
+        from sky.jobs.state import ManagedJobStatus
+
+        _, task_name, _ = SkypilotJobsExecutor.parse_app(app_id=app_id)
+        task_details = SkypilotJobsExecutor.status(app_id=app_id)
+
+        roles = [Role(name=task_name, image="", num_replicas=1)]
+        roles_statuses = [
+            RoleStatus(
+                task_name,
+                replicas=[
+                    ReplicaStatus(
+                        id=0,
+                        role=task_name,
+                        state=AppState.SUBMITTED,
+                        hostname="skypilot-api",
+                    )
+                ],
+            )
+        ]
+
+        if not task_details:
+            past_apps = _get_job_dirs()
+            if app_id in past_apps and "job_status" in past_apps[app_id]:
+                job_status = ManagedJobStatus[past_apps[app_id]["job_status"]]
+                app_state = SKYPILOT_STATES[job_status]
+                roles_statuses[0].replicas[0].state = app_state
+                return DescribeAppResponse(
+                    app_id=app_id,
+                    roles=roles,
+                    roles_statuses=roles_statuses,
+                    state=app_state,
+                    msg="",
+                )
+            else:
+                return None
+        else:
+            app_state = SKYPILOT_STATES[task_details["status"]]
+            _save_job_dir(
+                app_id,
+                job_status=task_details["status"].value,
+            )
+            roles_statuses[0].replicas[0].state = app_state
+            return DescribeAppResponse(
+                app_id=app_id,
+                roles=roles,
+                roles_statuses=roles_statuses,
+                state=app_state,
+                msg="",
+            )
+
+    def _cancel_existing(self, app_id: str) -> None:
+        SkypilotJobsExecutor.cancel(app_id=app_id)
+
+    def list(self) -> list[ListAppResponse]: ...
+
+
+def create_scheduler(session_name: str, **kwargs: Any) -> SkypilotJobsScheduler:
+    return SkypilotJobsScheduler(
+        session_name=session_name,
+    )
+
+
+def _save_job_dir(app_id: str, job_status: str) -> None:
+    original_apps = {}
+    if not os.path.isfile(SKYPILOT_JOB_DIRS):
+        os.makedirs(os.path.dirname(SKYPILOT_JOB_DIRS), exist_ok=True)
+        Path(SKYPILOT_JOB_DIRS).touch()
+
+    with open(SKYPILOT_JOB_DIRS, "r+") as f:
+        if FCNTL_AVAILABLE:
+            assert fcntl
+            fcntl.flock(f, fcntl.LOCK_EX)
+
+        try:
+            try:
+                original_apps = json.load(f)
+            except Exception:
+                original_apps = {}
+
+            app = {
+                "job_status": job_status,
+            }
+            original_apps[app_id] = app
+
+            with tempfile.NamedTemporaryFile(mode="w+") as fp:
+                json.dump(original_apps, fp)
+                fp.flush()
+
+                shutil.copy(fp.name, SKYPILOT_JOB_DIRS)
+                fp.close()
+        finally:
+            if FCNTL_AVAILABLE:
+                assert fcntl
+                fcntl.flock(f, fcntl.LOCK_UN)
+
+
+def _get_job_dirs() -> dict[str, dict[str, str]]:
+    try:
+        with open(SKYPILOT_JOB_DIRS, "r") as f:
+            apps: dict[str, dict[str, str]] = json.load(f)
+    except FileNotFoundError:
+        return {}
+
+    return apps

--- a/nemo_run/run/torchx_backend/schedulers/skypilot_jobs.py
+++ b/nemo_run/run/torchx_backend/schedulers/skypilot_jobs.py
@@ -56,6 +56,7 @@ try:
         ManagedJobStatus.FAILED_CONTROLLER: AppState.FAILED,
     }
 except ImportError:
+    # suppress import error so we don't crash if skypilot is not installed.
     pass
 
 SKYPILOT_JOB_DIRS = os.path.join(get_nemorun_home(), ".skypilot_jobs.json")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ local_persistent = "nemo_run.run.torchx_backend.schedulers.local:create_schedule
 docker_persistent = "nemo_run.run.torchx_backend.schedulers.docker:create_scheduler"
 dgx_cloud = "nemo_run.run.torchx_backend.schedulers.dgxcloud:create_scheduler"
 lepton = "nemo_run.run.torchx_backend.schedulers.lepton:create_scheduler"
+skypilot_jobs = "nemo_run.run.torchx_backend.schedulers.skypilot_jobs:create_scheduler"
 
 [project.optional-dependencies]
 skypilot = [

--- a/test/core/execution/test_skypilot_jobs.py
+++ b/test/core/execution/test_skypilot_jobs.py
@@ -1,0 +1,512 @@
+import os
+import tempfile
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+from nemo_run.core.execution.skypilot_jobs import SkypilotJobsExecutor
+from nemo_run.core.packaging.git import GitArchivePackager
+
+
+@pytest.fixture
+def mock_skypilot_imports():
+    class MockClusterNotUpError(Exception):
+        pass
+
+    sky_mock = MagicMock()
+    sky_task_mock = MagicMock()
+    backends_mock = MagicMock()
+    sky_jobs_mock = MagicMock()
+    job_status_mock = MagicMock()
+    job_status_mock.RUNNING = "RUNNING"
+    job_status_mock.SUCCEEDED = "SUCCEEDED"
+    job_status_mock.FAILED = "FAILED"
+    job_status_mock.is_terminal = MagicMock()
+
+    sky_exceptions_mock = MagicMock()
+    sky_exceptions_mock.ClusterNotUpError = MockClusterNotUpError
+
+    modules = {
+        "sky": sky_mock,
+        "sky.task": sky_task_mock,
+        "sky.backends": backends_mock,
+        "sky.jobs.client.sdk": sky_jobs_mock,
+        "sky.resources": MagicMock(),
+        "sky.exceptions": sky_exceptions_mock,
+    }
+
+    with patch.dict("sys.modules", modules):
+        with patch("nemo_run.core.execution.skypilot_jobs._SKYPILOT_AVAILABLE", True):
+            yield (
+                sky_mock,
+                sky_task_mock,
+                backends_mock,
+                sky_jobs_mock,
+                sky_exceptions_mock,
+                job_status_mock,
+            )
+
+
+class TestSkypilotJobsExecutor:
+    @pytest.fixture
+    def executor(self, mock_skypilot_imports):
+        return SkypilotJobsExecutor(
+            container_image="nvcr.io/nvidia/nemo:latest",
+            cloud="kubernetes",
+            cluster_name="test-cluster",
+            gpus="A100",
+            gpus_per_node=8,
+            num_nodes=2,
+            use_spot=True,
+            file_mounts={
+                "test_file": "/path/to/test_file",
+            },
+            setup="pip install -r requirements.txt",
+        )
+
+    def test_init(self, mock_skypilot_imports):
+        executor = SkypilotJobsExecutor(
+            container_image="nvcr.io/nvidia/nemo:latest",
+            cloud="kubernetes",
+            cluster_name="test-cluster",
+            gpus="A100",
+            gpus_per_node=8,
+        )
+
+        assert executor.container_image == "nvcr.io/nvidia/nemo:latest"
+        assert executor.cloud == "kubernetes"
+        assert executor.cluster_name == "test-cluster"
+        assert executor.gpus == "A100"
+        assert executor.gpus_per_node == 8
+        assert executor.num_nodes == 1
+        assert isinstance(executor.packager, GitArchivePackager)
+
+    def test_init_missing_skypilot(self):
+        with patch("nemo_run.core.execution.skypilot_jobs._SKYPILOT_AVAILABLE", False):
+            with pytest.raises(AssertionError, match="Skypilot is not installed"):
+                SkypilotJobsExecutor(
+                    container_image="nvcr.io/nvidia/nemo:latest",
+                    cloud="kubernetes",
+                )
+
+    def test_init_non_git_packager(self, mock_skypilot_imports):
+        non_git_packager = MagicMock()
+
+        with pytest.raises(AssertionError, match="Only GitArchivePackager is currently supported"):
+            SkypilotJobsExecutor(
+                container_image="nvcr.io/nvidia/nemo:latest",
+                cloud="kubernetes",
+                packager=non_git_packager,
+            )
+
+    def test_init_with_infra_and_cloud_fails(self, mock_skypilot_imports):
+        with pytest.raises(
+            AssertionError, match="Cannot specify both `infra` and `cloud` parameters."
+        ):
+            SkypilotJobsExecutor(
+                infra="my-infra",
+                cloud="aws",
+            )
+
+    def test_init_with_infra_and_region_fails(self, mock_skypilot_imports):
+        with pytest.raises(
+            AssertionError, match="Cannot specify both `infra` and `region` parameters."
+        ):
+            SkypilotJobsExecutor(
+                infra="my-infra",
+                region="us-west-2",
+            )
+
+    def test_init_with_infra_and_zone_fails(self, mock_skypilot_imports):
+        with pytest.raises(
+            AssertionError, match="Cannot specify both `infra` and `zone` parameters."
+        ):
+            SkypilotJobsExecutor(
+                infra="my-infra",
+                zone="us-west-2a",
+            )
+
+    def test_parse_app(self, mock_skypilot_imports):
+        # Note: SkypilotJobsExecutor uses 3 components instead of 4
+        app_id = "cluster-name___task-name___123"
+        cluster, task, job_id = SkypilotJobsExecutor.parse_app(app_id)
+
+        assert cluster == "cluster-name"
+        assert task == "task-name"
+        assert job_id == 123
+
+    def test_parse_app_invalid(self, mock_skypilot_imports):
+        # The implementation raises IndexError when the app_id format is invalid
+        with pytest.raises(IndexError):
+            SkypilotJobsExecutor.parse_app("invalid_app_id")
+
+        # Test with a partially valid app_id
+        with pytest.raises(IndexError):
+            SkypilotJobsExecutor.parse_app("cluster___task")
+
+    @patch("sky.resources.Resources")
+    def test_to_resources_with_gpu(self, mock_resources, mock_skypilot_imports, executor):
+        executor.to_resources()
+
+        mock_resources.from_yaml_config.assert_called_once()
+        config = mock_resources.from_yaml_config.call_args[0][0]
+        assert "accelerators" in config
+        assert config["accelerators"] == {"A100": 8}
+
+    @patch("sky.resources.Resources")
+    def test_to_resources_with_container(self, mock_resources, mock_skypilot_imports):
+        executor = SkypilotJobsExecutor(
+            container_image="nvcr.io/nvidia/nemo:latest",
+            cloud="kubernetes",
+        )
+
+        executor.to_resources()
+
+        mock_resources.from_yaml_config.assert_called_once()
+        config = mock_resources.from_yaml_config.call_args[0][0]
+        assert config["image_id"] == "nvcr.io/nvidia/nemo:latest"
+
+    @patch("sky.resources.Resources")
+    def test_to_resources_with_list_values(self, mock_resources, mock_skypilot_imports):
+        executor = SkypilotJobsExecutor(
+            cloud=["aws", "azure"],
+            region=["us-west-2", "eastus"],
+            cpus=[16, 8],
+            memory=[64, 32],
+        )
+
+        executor.to_resources()
+
+        mock_resources.from_yaml_config.assert_called_once()
+        config = mock_resources.from_yaml_config.call_args[0][0]
+        assert len(config["any_of"]) == 2
+        assert config["any_of"][0]["cloud"] == "aws"
+        assert config["any_of"][0]["region"] == "us-west-2"
+        assert config["any_of"][0]["cpus"] == 16
+        assert config["any_of"][0]["memory"] == 64
+        assert config["any_of"][1]["cloud"] == "azure"
+        assert config["any_of"][1]["region"] == "eastus"
+        assert config["any_of"][1]["cpus"] == 8
+        assert config["any_of"][1]["memory"] == 32
+
+    @patch("sky.resources.Resources")
+    def test_to_resources_with_none_string(self, mock_resources, mock_skypilot_imports):
+        executor = SkypilotJobsExecutor(
+            cloud="none",
+            region=["us-west-2", "none"],
+        )
+
+        executor.to_resources()
+
+        mock_resources.from_yaml_config.assert_called_once()
+        config = mock_resources.from_yaml_config.call_args[0][0]
+        assert config["cloud"] is None
+        assert config["any_of"][1]["region"] is None
+
+    @patch("sky.resources.Resources")
+    def test_to_resources_with_infra_and_network_tier(self, mock_resources, mock_skypilot_imports):
+        executor = SkypilotJobsExecutor(infra="k8s/my-context", network_tier="best")
+
+        executor.to_resources()
+
+        mock_resources.from_yaml_config.assert_called_once()
+
+        config = mock_resources.from_yaml_config.call_args[0][0]
+        assert config["infra"] == "k8s/my-context"
+        assert config["network_tier"] == "best"
+
+    @patch("sky.stream_and_get")
+    @patch("sky.jobs.client.sdk.queue")
+    @patch("nemo_run.core.execution.skypilot_jobs.SkypilotJobsExecutor.parse_app")
+    def test_status_success(self, mock_parse_app, mock_queue, mock_stream_and_get):
+        mock_job_details = {"job_id": 123, "status": "RUNNING"}
+        mock_stream_and_get.return_value = [mock_job_details]
+        mock_parse_app.return_value = ("cluster-name", "task-name", 123)
+
+        details = SkypilotJobsExecutor.status("cluster-name___task-name___123")
+
+        assert details == mock_job_details
+        mock_stream_and_get.assert_called_once()
+        mock_queue.assert_called_once_with(refresh=True, all_users=True, job_ids=[123])
+
+    @patch("sky.stream_and_get")
+    @patch("sky.jobs.client.sdk.queue")
+    @patch("nemo_run.core.execution.skypilot_jobs.SkypilotJobsExecutor.parse_app")
+    def test_status_cluster_not_up(self, mock_parse_app, mock_queue, mock_stream_and_get):
+        class MockClusterNotUpError(Exception):
+            pass
+
+        mock_stream_and_get.side_effect = MockClusterNotUpError("Cluster not up")
+        mock_parse_app.return_value = ("cluster-name", "task-name", 123)
+
+        with patch("sky.exceptions.ClusterNotUpError", MockClusterNotUpError):
+            job_details = SkypilotJobsExecutor.status("cluster-name___task-name___123")
+            assert job_details is None
+
+    @patch("sky.jobs.client.sdk.tail_logs")
+    @patch("nemo_run.core.execution.skypilot_jobs.SkypilotJobsExecutor.status")
+    @patch("nemo_run.core.execution.skypilot_jobs.SkypilotJobsExecutor.parse_app")
+    def test_logs_running_job(self, mock_parse_app, mock_status, mock_tail_logs):
+        mock_parse_app.return_value = ("cluster-name", "task-name", 123)
+        mock_job_status = MagicMock()
+        mock_job_status.is_terminal.return_value = False
+        mock_status.return_value = {"job_id": 123, "status": mock_job_status}
+
+        SkypilotJobsExecutor.logs("cluster-name___task-name___123", "/path/to/logs")
+
+        mock_tail_logs.assert_called_once_with(job_id=123)
+
+    @patch("nemo_run.core.execution.skypilot_jobs.SkypilotJobsExecutor.status")
+    @patch("nemo_run.core.execution.skypilot_jobs.SkypilotJobsExecutor.parse_app")
+    @patch("builtins.open", new_callable=mock_open, read_data="Test log content")
+    @patch("os.path.isfile")
+    @patch("builtins.print")
+    def test_logs_terminal_job_fallback(
+        self, mock_print, mock_isfile, mock_open, mock_parse_app, mock_status
+    ):
+        mock_parse_app.return_value = ("cluster-name", "task-name", 123)
+        mock_job_status = MagicMock()
+        mock_job_status.is_terminal.return_value = True
+        mock_status.return_value = {"job_id": 123, "status": mock_job_status}
+        mock_isfile.return_value = True
+
+        SkypilotJobsExecutor.logs("cluster-name___task-name___123", "/path/to/logs")
+
+        mock_open.assert_called_once()
+        mock_print.assert_called_with("Test log content", end="", flush=True)
+
+    @patch("sky.jobs.client.sdk.cancel")
+    @patch("nemo_run.core.execution.skypilot_jobs.SkypilotJobsExecutor.status")
+    @patch("nemo_run.core.execution.skypilot_jobs.SkypilotJobsExecutor.parse_app")
+    def test_cancel(self, mock_parse_app, mock_status, mock_cancel):
+        mock_parse_app.return_value = ("cluster-name", "task-name", 123)
+        mock_status.return_value = {"job_id": 123, "status": "RUNNING"}
+
+        SkypilotJobsExecutor.cancel("cluster-name___task-name___123")
+
+        mock_cancel.assert_called_once_with(job_ids=[123])
+
+    @patch("sky.jobs.client.sdk.cancel")
+    @patch("nemo_run.core.execution.skypilot_jobs.SkypilotJobsExecutor.status")
+    @patch("nemo_run.core.execution.skypilot_jobs.SkypilotJobsExecutor.parse_app")
+    def test_cancel_no_job(self, mock_parse_app, mock_status, mock_cancel):
+        mock_parse_app.return_value = ("cluster-name", "task-name", 123)
+        mock_status.return_value = None
+
+        SkypilotJobsExecutor.cancel("cluster-name___task-name___123")
+
+        mock_cancel.assert_not_called()
+
+    @patch("sky.stream_and_get")
+    @patch("sky.jobs.client.sdk.launch")
+    def test_launch(self, mock_launch, mock_stream_and_get, executor):
+        mock_handle = MagicMock()
+        mock_launch.return_value = MagicMock()
+        mock_stream_and_get.return_value = (123, mock_handle)
+
+        job_id, handle = executor.launch(MagicMock())
+
+        assert job_id == 123
+        assert handle is mock_handle
+
+    def test_workdir(self, executor):
+        executor.job_dir = "/path/to/job"
+        assert executor.workdir == "/path/to/job/workdir"
+
+    @patch("os.path.exists")
+    def test_package_configs(self, mock_exists, executor):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            executor.job_dir = tmp_dir
+            mock_exists.return_value = True
+            configs = executor.package_configs(
+                ("config1.yaml", "content1"), ("config2.yaml", "content2")
+            )
+
+            assert len(configs) == 2
+            assert configs[0].endswith("config1.yaml")
+            assert configs[1].endswith("config2.yaml")
+
+    def test_assign(self, executor):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            executor.assign(
+                exp_id="test_exp",
+                exp_dir=tmp_dir,
+                task_id="test_task",
+                task_dir="test_task_dir",
+            )
+
+            assert executor.experiment_id == "test_exp"
+            assert executor.experiment_dir == tmp_dir
+            assert executor.job_dir == os.path.join(tmp_dir, "test_task_dir")
+            assert executor.job_name == "test_task"
+
+    def test_nnodes(self, executor):
+        assert executor.nnodes() == 2
+
+        default_executor = SkypilotJobsExecutor(container_image="test:latest")
+        assert default_executor.nnodes() == 1
+
+    def test_nproc_per_node(self, executor):
+        assert executor.nproc_per_node() == 8
+
+        executor.torchrun_nproc_per_node = 4
+        assert executor.nproc_per_node() == 4
+
+    def test_macro_values(self, executor):
+        macro_values = executor.macro_values()
+
+        assert macro_values is not None
+        assert macro_values.head_node_ip_var == "head_node_ip"
+        assert macro_values.nproc_per_node_var == "SKYPILOT_NUM_GPUS_PER_NODE"
+        assert macro_values.num_nodes_var == "num_nodes"
+        assert macro_values.node_rank_var == "SKYPILOT_NODE_RANK"
+        assert macro_values.het_group_host_var == "het_group_host"
+
+    @patch("sky.task.Task")
+    def test_to_task(self, mock_task, mock_skypilot_imports, executor):
+        mock_task_instance = MagicMock()
+        mock_task.return_value = mock_task_instance
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            executor.job_dir = tmp_dir
+            executor.file_mounts = {"test_file": "/path/to/test_file"}
+
+            result = executor.to_task("test_task", ["python", "train.py"], {"TEST_VAR": "test_value"})
+
+            mock_task.assert_called_once()
+            assert mock_task.call_args[1]["name"] == "test_task"
+            assert mock_task.call_args[1]["num_nodes"] == 2
+            mock_task_instance.set_file_mounts.assert_called_once()
+            mock_task_instance.set_resources.assert_called_once()
+            mock_task_instance.update_envs.assert_called_once_with({"TEST_VAR": "test_value"})
+            assert result == mock_task_instance
+
+    @patch("sky.task.Task")
+    def test_to_task_with_storage_mounts(self, mock_task, mock_skypilot_imports):
+        # Create a mock task instance
+        mock_task_instance = MagicMock()
+        mock_task.return_value = mock_task_instance
+        mock_task_instance.set_file_mounts = MagicMock()
+        mock_task_instance.set_storage_mounts = MagicMock()
+        mock_task_instance.set_resources = MagicMock()
+
+        # Mock sky.data.Storage
+        mock_storage_class = MagicMock()
+        mock_storage_obj = MagicMock()
+        mock_storage_class.from_yaml_config.return_value = mock_storage_obj
+
+        executor = SkypilotJobsExecutor(
+            container_image="test:latest",
+            storage_mounts={
+                "/workspace/outputs": {
+                    "name": "my-outputs",
+                    "store": "gcs",
+                    "mode": "MOUNT",
+                    "persistent": True,
+                }
+            },
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            executor.job_dir = tmp_dir
+
+            with patch("sky.data.Storage", mock_storage_class):
+                executor.to_task("test_task")
+
+                # Verify Storage.from_yaml_config was called with the config
+                mock_storage_class.from_yaml_config.assert_called_once_with(
+                    {
+                        "name": "my-outputs",
+                        "store": "gcs",
+                        "mode": "MOUNT",
+                        "persistent": True,
+                    }
+                )
+
+                # Verify set_storage_mounts was called with Storage objects
+                mock_task_instance.set_storage_mounts.assert_called_once()
+                storage_mounts_call = mock_task_instance.set_storage_mounts.call_args[0][0]
+                assert "/workspace/outputs" in storage_mounts_call
+                assert storage_mounts_call["/workspace/outputs"] == mock_storage_obj
+
+    @patch("sky.task.Task")
+    def test_to_task_with_both_file_and_storage_mounts(self, mock_task, mock_skypilot_imports):
+        # Create a mock task instance
+        mock_task_instance = MagicMock()
+        mock_task.return_value = mock_task_instance
+        mock_task_instance.set_file_mounts = MagicMock()
+        mock_task_instance.set_storage_mounts = MagicMock()
+        mock_task_instance.set_resources = MagicMock()
+
+        # Mock sky.data.Storage
+        mock_storage_class = MagicMock()
+        mock_storage_obj = MagicMock()
+        mock_storage_class.from_yaml_config.return_value = mock_storage_obj
+
+        executor = SkypilotJobsExecutor(
+            container_image="test:latest",
+            file_mounts={
+                "/workspace/code": "/local/path/to/code",
+            },
+            storage_mounts={
+                "/workspace/outputs": {
+                    "name": "my-outputs",
+                    "store": "s3",
+                    "mode": "MOUNT",
+                },
+                "/workspace/checkpoints": {
+                    "name": "my-checkpoints",
+                    "store": "gcs",
+                    "mode": "MOUNT_CACHED",
+                },
+            },
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            executor.job_dir = tmp_dir
+
+            with patch("sky.data.Storage", mock_storage_class):
+                executor.to_task("test_task")
+
+                # Verify file_mounts includes both user files and nemo_run
+                file_mounts_call = mock_task_instance.set_file_mounts.call_args[0][0]
+                assert "/workspace/code" in file_mounts_call
+                assert file_mounts_call["/workspace/code"] == "/local/path/to/code"
+                assert "/nemo_run" in file_mounts_call
+                assert file_mounts_call["/nemo_run"] == tmp_dir
+
+                # Verify Storage.from_yaml_config was called for both storage mounts
+                assert mock_storage_class.from_yaml_config.call_count == 2
+
+                # Verify set_storage_mounts was called with both Storage objects
+                mock_task_instance.set_storage_mounts.assert_called_once()
+                storage_mounts_call = mock_task_instance.set_storage_mounts.call_args[0][0]
+                assert "/workspace/outputs" in storage_mounts_call
+                assert "/workspace/checkpoints" in storage_mounts_call
+                assert len(storage_mounts_call) == 2
+
+    @patch("sky.task.Task")
+    def test_to_task_without_storage_mounts(self, mock_task, mock_skypilot_imports):
+        # Test that set_storage_mounts is not called when storage_mounts is None
+        mock_task_instance = MagicMock()
+        mock_task.return_value = mock_task_instance
+        mock_task_instance.set_file_mounts = MagicMock()
+        mock_task_instance.set_storage_mounts = MagicMock()
+        mock_task_instance.set_resources = MagicMock()
+
+        executor = SkypilotJobsExecutor(
+            container_image="test:latest",
+            file_mounts={"/workspace/code": "/local/path"},
+            storage_mounts=None,  # Explicitly set to None
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            executor.job_dir = tmp_dir
+
+            executor.to_task("test_task")
+
+            # Verify set_storage_mounts was NOT called
+            mock_task_instance.set_storage_mounts.assert_not_called()
+
+            # Verify file_mounts still works
+            mock_task_instance.set_file_mounts.assert_called_once()

--- a/test/core/execution/test_skypilot_jobs.py
+++ b/test/core/execution/test_skypilot_jobs.py
@@ -371,7 +371,9 @@ class TestSkypilotJobsExecutor:
             executor.job_dir = tmp_dir
             executor.file_mounts = {"test_file": "/path/to/test_file"}
 
-            result = executor.to_task("test_task", ["python", "train.py"], {"TEST_VAR": "test_value"})
+            result = executor.to_task(
+                "test_task", ["python", "train.py"], {"TEST_VAR": "test_value"}
+            )
 
             mock_task.assert_called_once()
             assert mock_task.call_args[1]["name"] == "test_task"

--- a/test/run/torchx_backend/schedulers/test_skypilot_jobs.py
+++ b/test/run/torchx_backend/schedulers/test_skypilot_jobs.py
@@ -1,0 +1,144 @@
+import tempfile
+from unittest import mock
+
+import pytest
+from torchx.schedulers.api import AppDryRunInfo
+from torchx.specs import AppDef, Role
+
+from nemo_run.core.execution.skypilot_jobs import SkypilotJobsExecutor
+from nemo_run.run.torchx_backend.schedulers.skypilot_jobs import (
+    SkypilotJobsScheduler,
+    create_scheduler,
+)
+
+
+@pytest.fixture
+def mock_app_def():
+    return AppDef(name="test_app", roles=[Role(name="test_role", image="")])
+
+
+@pytest.fixture
+def skypilot_jobs_executor():
+    return SkypilotJobsExecutor(
+        job_dir=tempfile.mkdtemp(),
+        gpus="V100",
+        gpus_per_node=1,
+        cloud="aws",
+    )
+
+
+@pytest.fixture
+def skypilot_jobs_scheduler():
+    return create_scheduler(session_name="test_session")
+
+
+def test_create_scheduler():
+    scheduler = create_scheduler(session_name="test_session")
+    assert isinstance(scheduler, SkypilotJobsScheduler)
+    assert scheduler.session_name == "test_session"
+
+
+def test_skypilot_jobs_scheduler_methods(skypilot_jobs_scheduler):
+    assert hasattr(skypilot_jobs_scheduler, "_submit_dryrun")
+    assert hasattr(skypilot_jobs_scheduler, "schedule")
+    assert hasattr(skypilot_jobs_scheduler, "describe")
+    assert hasattr(skypilot_jobs_scheduler, "_validate")
+
+
+def test_submit_dryrun(skypilot_jobs_scheduler, mock_app_def, skypilot_jobs_executor):
+    with mock.patch.object(SkypilotJobsExecutor, "package") as mock_package:
+        mock_package.return_value = None
+
+        dryrun_info = skypilot_jobs_scheduler._submit_dryrun(mock_app_def, skypilot_jobs_executor)
+        assert isinstance(dryrun_info, AppDryRunInfo)
+        assert dryrun_info.request is not None
+
+
+def test_schedule(skypilot_jobs_scheduler, mock_app_def, skypilot_jobs_executor):
+    class MockHandle:
+        def get_cluster_name(self):
+            return "test_cluster_name"
+
+    with (
+        mock.patch.object(SkypilotJobsExecutor, "package") as mock_package,
+        mock.patch.object(SkypilotJobsExecutor, "launch") as mock_launch,
+        mock.patch.object(SkypilotJobsExecutor, "status") as mock_status,
+    ):
+        mock_package.return_value = None
+        mock_launch.return_value = (123, MockHandle())
+        mock_status.return_value = None
+
+        skypilot_jobs_executor.job_name = "test_job"
+        skypilot_jobs_executor.experiment_id = "test_session"
+
+        dryrun_info = skypilot_jobs_scheduler._submit_dryrun(mock_app_def, skypilot_jobs_executor)
+        app_id = skypilot_jobs_scheduler.schedule(dryrun_info)
+
+        # Note: SkypilotJobsExecutor uses 3-component app_id format (no experiment_id prefix)
+        assert app_id == "test_cluster_name___test_role___123"
+        mock_package.assert_called_once()
+        mock_launch.assert_called_once()
+
+
+def test_cancel_existing(skypilot_jobs_scheduler):
+    with mock.patch.object(SkypilotJobsExecutor, "cancel") as mock_cancel:
+        skypilot_jobs_scheduler._cancel_existing("test_cluster_name___test_role___123")
+        mock_cancel.assert_called_once_with(app_id="test_cluster_name___test_role___123")
+
+
+def test_describe_no_status(skypilot_jobs_scheduler):
+    with (
+        mock.patch.object(SkypilotJobsExecutor, "status") as mock_status,
+        mock.patch("nemo_run.run.torchx_backend.schedulers.skypilot_jobs._get_job_dirs") as mock_get_job_dirs,
+    ):
+        mock_status.return_value = None
+        mock_get_job_dirs.return_value = {}
+
+        result = skypilot_jobs_scheduler.describe("test_cluster___test_role___123")
+        assert result is None
+
+
+def test_describe_with_status(skypilot_jobs_scheduler):
+    from sky.jobs.state import ManagedJobStatus
+
+    task_details = {
+        "status": ManagedJobStatus.RUNNING,
+        "job_id": 123
+    }
+
+    with (
+        mock.patch.object(SkypilotJobsExecutor, "status") as mock_status,
+        mock.patch("nemo_run.run.torchx_backend.schedulers.skypilot_jobs._save_job_dir") as mock_save,
+    ):
+        mock_status.return_value = task_details
+
+        result = skypilot_jobs_scheduler.describe("test_cluster___test_role___123")
+
+        assert result is not None
+        assert result.app_id == "test_cluster___test_role___123"
+        assert len(result.roles) == 1
+        assert result.roles[0].name == "test_role"
+        mock_save.assert_called_once()
+
+
+def test_describe_with_past_jobs(skypilot_jobs_scheduler):
+    past_apps = {
+        "test_cluster___test_role___123": {
+            "job_status": "SUCCEEDED"
+        }
+    }
+
+    with (
+        mock.patch.object(SkypilotJobsExecutor, "status") as mock_status,
+        mock.patch("nemo_run.run.torchx_backend.schedulers.skypilot_jobs._get_job_dirs") as mock_get_job_dirs,
+    ):
+        mock_status.return_value = None
+        mock_get_job_dirs.return_value = past_apps
+
+        result = skypilot_jobs_scheduler.describe("test_cluster___test_role___123")
+
+        assert result is not None
+        assert result.app_id == "test_cluster___test_role___123"
+        # The state should be mapped from SUCCEEDED status
+        from torchx.specs import AppState
+        assert result.state == AppState.SUCCEEDED

--- a/test/run/torchx_backend/schedulers/test_skypilot_jobs.py
+++ b/test/run/torchx_backend/schedulers/test_skypilot_jobs.py
@@ -89,7 +89,9 @@ def test_cancel_existing(skypilot_jobs_scheduler):
 def test_describe_no_status(skypilot_jobs_scheduler):
     with (
         mock.patch.object(SkypilotJobsExecutor, "status") as mock_status,
-        mock.patch("nemo_run.run.torchx_backend.schedulers.skypilot_jobs._get_job_dirs") as mock_get_job_dirs,
+        mock.patch(
+            "nemo_run.run.torchx_backend.schedulers.skypilot_jobs._get_job_dirs"
+        ) as mock_get_job_dirs,
     ):
         mock_status.return_value = None
         mock_get_job_dirs.return_value = {}
@@ -101,14 +103,13 @@ def test_describe_no_status(skypilot_jobs_scheduler):
 def test_describe_with_status(skypilot_jobs_scheduler):
     from sky.jobs.state import ManagedJobStatus
 
-    task_details = {
-        "status": ManagedJobStatus.RUNNING,
-        "job_id": 123
-    }
+    task_details = {"status": ManagedJobStatus.RUNNING, "job_id": 123}
 
     with (
         mock.patch.object(SkypilotJobsExecutor, "status") as mock_status,
-        mock.patch("nemo_run.run.torchx_backend.schedulers.skypilot_jobs._save_job_dir") as mock_save,
+        mock.patch(
+            "nemo_run.run.torchx_backend.schedulers.skypilot_jobs._save_job_dir"
+        ) as mock_save,
     ):
         mock_status.return_value = task_details
 
@@ -122,15 +123,13 @@ def test_describe_with_status(skypilot_jobs_scheduler):
 
 
 def test_describe_with_past_jobs(skypilot_jobs_scheduler):
-    past_apps = {
-        "test_cluster___test_role___123": {
-            "job_status": "SUCCEEDED"
-        }
-    }
+    past_apps = {"test_cluster___test_role___123": {"job_status": "SUCCEEDED"}}
 
     with (
         mock.patch.object(SkypilotJobsExecutor, "status") as mock_status,
-        mock.patch("nemo_run.run.torchx_backend.schedulers.skypilot_jobs._get_job_dirs") as mock_get_job_dirs,
+        mock.patch(
+            "nemo_run.run.torchx_backend.schedulers.skypilot_jobs._get_job_dirs"
+        ) as mock_get_job_dirs,
     ):
         mock_status.return_value = None
         mock_get_job_dirs.return_value = past_apps
@@ -141,4 +140,5 @@ def test_describe_with_past_jobs(skypilot_jobs_scheduler):
         assert result.app_id == "test_cluster___test_role___123"
         # The state should be mapped from SUCCEEDED status
         from torchx.specs import AppState
+
         assert result.state == AppState.SUCCEEDED

--- a/test/run/torchx_backend/schedulers/test_skypilot_jobs.py
+++ b/test/run/torchx_backend/schedulers/test_skypilot_jobs.py
@@ -1,7 +1,6 @@
 import json
 import os
 import tempfile
-from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -157,8 +156,7 @@ def test_save_job_dir_new_file():
 
     try:
         with mock.patch(
-            "nemo_run.run.torchx_backend.schedulers.skypilot_jobs.SKYPILOT_JOB_DIRS",
-            temp_path
+            "nemo_run.run.torchx_backend.schedulers.skypilot_jobs.SKYPILOT_JOB_DIRS", temp_path
         ):
             _save_job_dir("test_app_id", "RUNNING")
 
@@ -182,8 +180,7 @@ def test_save_job_dir_existing_file():
 
     try:
         with mock.patch(
-            "nemo_run.run.torchx_backend.schedulers.skypilot_jobs.SKYPILOT_JOB_DIRS",
-            temp_path
+            "nemo_run.run.torchx_backend.schedulers.skypilot_jobs.SKYPILOT_JOB_DIRS", temp_path
         ):
             _save_job_dir("new_app_id", "PENDING")
 
@@ -212,8 +209,7 @@ def test_get_job_dirs_existing_file():
 
     try:
         with mock.patch(
-            "nemo_run.run.torchx_backend.schedulers.skypilot_jobs.SKYPILOT_JOB_DIRS",
-            temp_path
+            "nemo_run.run.torchx_backend.schedulers.skypilot_jobs.SKYPILOT_JOB_DIRS", temp_path
         ):
             result = _get_job_dirs()
             assert result == test_data
@@ -227,8 +223,7 @@ def test_get_job_dirs_file_not_found():
     non_existent_path = "/tmp/definitely_does_not_exist_12345.json"
 
     with mock.patch(
-        "nemo_run.run.torchx_backend.schedulers.skypilot_jobs.SKYPILOT_JOB_DIRS",
-        non_existent_path
+        "nemo_run.run.torchx_backend.schedulers.skypilot_jobs.SKYPILOT_JOB_DIRS", non_existent_path
     ):
         result = _get_job_dirs()
         assert result == {}


### PR DESCRIPTION
# Problem
The `SkypilotExecutor` cannot launch [skypilot managed jobs](https://docs.skypilot.co/en/latest/examples/managed-jobs.html), which support features such as automatic retries and recovery from spot preemptions.

Managed jobs use a different sdk than regular jobs. As such, the `SkypilotExecutor` cannot be used to launch both types of jobs.

# Solution
This pr adds a `SkypilotJobsExecutor` and `SkypilotJobsScheduler`, which use the jobs sdk to launch managed jobs. The executor works with local and remote Skypilot API servers.

# Example usage
```
executor = run.SkypilotJobsExecutor(
    gpus="H100",
    launcher="torchrun",
    gpus_per_node=8,
    env_vars={},
    num_nodes=4,
    container_image="nvcr.io/nvidia/nemo:dev",
    infra="kubernetes",
    idle_minutes_to_autostop=10,
    autodown=True,
    packager=run.GitArchivePackager(subpath="nemo_training"),
)
run.run(recipe, executor=executor, name=experiment_name, log_level="DEBUG")
```

# Testing Strategy
- Tested with a remote and local api server
- Unit tests