### PR TITLE
Fix -y short flag collision between --yaml and --yes (#559)

### DIFF
--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -346,7 +346,7 @@ Train a model using the specified configuration.
 │ --dryrun                                                   Print the scheduler request without submitting
 │ --factory               -f                           TEXT  Predefined factory to use [default: None]
 │ --load                  -l                           TEXT  Load a factory from a directory [default: None]
-│ --yaml                  -y                           TEXT  Path to a YAML file to load [default: None]
+│ --yaml                                               TEXT  Path to a YAML file to load [default: None]
 │ --repl                  -r                                 Enter interactive mode
 │ --detach                                                   Detach from the run
 │ --yes,--no-confirm      -y                                 Skip confirmation before execution

--- a/nemo_run/cli/api.py
+++ b/nemo_run/cli/api.py
@@ -890,9 +890,7 @@ class RunContext:
             load: Optional[str] = typer.Option(
                 None, "--load", "-l", help="Load a factory from a directory"
             ),
-            yaml: Optional[str] = typer.Option(
-                None, "--yaml", "-y", help="Path to a YAML file to load"
-            ),
+            yaml: Optional[str] = typer.Option(None, "--yaml", help="Path to a YAML file to load"),
             repl: bool = typer.Option(False, "--repl", "-r", help="Enter interactive mode"),
             detach: bool = typer.Option(False, "--detach", help="Detach from the run"),
             skip_confirmation: bool = typer.Option(

--- a/nemo_run/cli/api.py
+++ b/nemo_run/cli/api.py
@@ -891,7 +891,7 @@ class RunContext:
                 None, "--load", "-l", help="Load a factory from a directory"
             ),
             yaml: Optional[str] = typer.Option(
-                None, "--yaml", "-y", help="Path to a YAML file to load"
+                None, "--yaml", help="Path to a YAML file to load"
             ),
             repl: bool = typer.Option(False, "--repl", "-r", help="Enter interactive mode"),
             detach: bool = typer.Option(False, "--detach", help="Detach from the run"),

--- a/test/cli/test_api.py
+++ b/test/cli/test_api.py
@@ -1918,3 +1918,23 @@ class TestExtractConstituentTypes:
     def test_various_type_hints(self, type_hint, expected_types):
         """Test get_underlying_types with various type hints."""
         assert extract_constituent_types(type_hint) == expected_types
+
+
+class TestShortFlagCollision:
+    """Regression test for issue #559: -y was bound to both --yaml and --yes."""
+
+    def test_short_flag_y_belongs_only_to_yes(self):
+        @run.cli.entrypoint
+        def dummy_task(yaml: Optional[str] = typer.Option(None, "--yaml", help="YAML file")):
+            return yaml
+
+        app = typer.Typer()
+        RunContext.cli_command(app, "task", dummy_task)
+        params = typer.main.get_command(app).params
+
+        opts = {param.name: param.opts for param in params}
+        assert opts["yaml"] == ["--yaml"]
+        assert "-y" in opts["skip_confirmation"]
+
+        shorts = [opt for param in params for opt in param.opts if len(opt) == 2]
+        assert len(shorts) == len(set(shorts)), f"duplicate short flags: {shorts}"


### PR DESCRIPTION
## Summary
In `RunContext.cli_command` (`nemo_run/cli/api.py`), both `--yaml` and `--yes/--no-confirm` claimed the short flag `-y`, so Click emitted a warning on every invocation. This drops `-y` from `--yaml` and keeps it as the conventional alias for `--yes`.

Closes #559

cc @hemildesai @marcromeyn