### PR TITLE
fix: use title in Experiment.from_title not found message

### DIFF
--- a/nemo_run/run/experiment.py
+++ b/nemo_run/run/experiment.py
@@ -291,7 +291,7 @@ nemo experiment cancel {exp_id} 0
         parent_dir = os.path.join(get_nemorun_home(), "experiments", title)
         exp_dir = _get_latest_dir(parent_dir)
 
-        assert os.path.isdir(exp_dir), f"Experiment {id} not found."
+        assert os.path.isdir(exp_dir), f"Experiment {title} not found."
 
         exp = cls._from_config(exp_dir)
         return exp

--- a/test/run/test_experiment.py
+++ b/test/run/test_experiment.py
@@ -436,7 +436,7 @@ def test_from_title_nonexistent(temp_dir):
         mock_get_latest_dir.return_value = nonexistent_path
 
         # The assertion should fail because the directory doesn't exist
-        with pytest.raises(AssertionError):
+        with pytest.raises(AssertionError, match=f"Experiment {title} not found"):
             Experiment.from_title(title)
 
 


### PR DESCRIPTION
## Bug\n`Experiment.from_title` referenced the built-in `id()` function in its assertion message, producing `Experiment <built-in function id> not found.` when the experiment directory was missing.\n\n## Fix\nUse the `title` parameter in the message instead.\n\n## Test\nUpdated `test_from_title_nonexistent` to assert that the error message contains the title.\n\n## Verification\n`uv run pytest test/run/test_experiment.py::test_from_title_nonexistent -v` passes.\n`uv run --group lint ruff check ...` and `ruff format --check ...` pass.