### PR TITLE
fix: preserve falsy primitive args in Config/Partial binding

### DIFF
--- a/nemo_run/config.py
+++ b/nemo_run/config.py
@@ -577,7 +577,7 @@ def _construct_args(
     for name, parameter in params.items():
         arg = kwargs.get(name, None)
 
-        if arg:
+        if arg is not None:
             if dataclasses.is_dataclass(arg):
                 final_args[name] = fdl.cast(
                     Config,

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -66,6 +66,10 @@ def train_manual(
     return optim
 
 
+def with_falsy_values(count: int = 1, flag: bool = True, label: str = "x"):
+    return count, flag, label
+
+
 @dataclass
 class Data:
     name: str
@@ -221,6 +225,13 @@ class TestPartial:
         fn = fdl.build(partial)
 
         assert fn() == fdl.build(optimizer())
+
+    def test_falsy_primitive_args_are_preserved(self):
+        """Falsy primitive values like 0, False, and '' must not be dropped."""
+        partial = run.Partial(with_falsy_values, count=0, flag=False, label="")
+        fn = fdl.build(partial)
+
+        assert fn() == (0, False, "")
 
     def test_clone(self):
         partial = run.Partial(train, model=dummy_model(), optim=optimizer())


### PR DESCRIPTION
## Bug

`_construct_args` used `if arg:` to decide whether to copy a keyword argument, which treated `0`, `False`, and `""` as missing.

## Fix

Use `if arg is not None:` so legitimate falsy values are preserved during binding.

## Test

Added `TestPartial::test_falsy_primitive_args_are_preserved`, which verifies that `0`, `False`, and empty-string args survive `run.Partial` construction and `fdl.build`.

## Verification

`uv run pytest test/test_config.py::TestPartial::test_falsy_primitive_args_are_preserved -v` passes.
`uv run --group lint ruff check nemo_run/config.py test/test_config.py` and `ruff format --check ...` pass.