### PR TITLE
fix: correct return type annotation of get_nsys_entrypoint

### DIFF
--- a/nemo_run/core/execution/base.py
+++ b/nemo_run/core/execution/base.py
@@ -165,7 +165,7 @@ class Executor(ConfigurableMixin):
             os.makedirs(os.path.join(self.job_dir, launcher.nsys_folder), exist_ok=True)
             return launcher.get_nsys_prefix(profile_dir=self.job_dir)
 
-    def get_nsys_entrypoint(self) -> str:
+    def get_nsys_entrypoint(self) -> tuple[str, str]:
         return ("nsys", "")
 
     def supports_launcher_transform(self) -> bool:

--- a/nemo_run/core/execution/slurm.py
+++ b/nemo_run/core/execution/slurm.py
@@ -561,7 +561,7 @@ class SlurmExecutor(Executor):
                 nsys_prefix += ["$GPU_METRICS_FLAG"]
         return nsys_prefix
 
-    def get_nsys_entrypoint(self) -> str:
+    def get_nsys_entrypoint(self) -> tuple[str, str]:
         launcher = self.get_launcher()
         entrypoint, postfix = "nsys", ""
         if launcher.nsys_gpu_metrics:


### PR DESCRIPTION
## Bug

`get_nsys_entrypoint` returns a tuple `("nsys", "")`, but its annotation was `str`. This mismatched the implementation and callers that unpack the result.

## Fix

Update the return type annotation to `tuple[str, str]`.

## Test

The existing `TestExecutor::test_get_nsys_entrypoint` already asserts the tuple return value.

## Verification

`uv run pytest test/core/execution/test_base.py::TestExecutor::test_get_nsys_entrypoint -v` passes. `uv run --group lint ruff check ...` and `ruff format --check ...` pass.