### PR TITLE
Let downstream executors opt in to JobGroup (#537)

### DIFF
--- a/nemo_run/core/execution/base.py
+++ b/nemo_run/core/execution/base.py
@@ -102,6 +102,14 @@ class Executor(ConfigurableMixin):
     def info(self) -> str:
         return self.__class__.__qualname__
 
+    @classmethod
+    def supports_job_group(cls) -> bool:
+        """Whether this executor can back a :class:`~nemo_run.run.job.JobGroup`.
+
+        Executors defined outside nemo_run opt in by overriding this to return True.
+        """
+        return False
+
     def clone(self) -> Self:
         return fdl.build(self.to_config())
 

--- a/nemo_run/core/execution/docker.py
+++ b/nemo_run/core/execution/docker.py
@@ -139,6 +139,10 @@ class DockerExecutor(Executor):
     resource_group: list["DockerExecutor"] = field(init=False, default_factory=list)
 
     @classmethod
+    def supports_job_group(cls) -> bool:
+        return True
+
+    @classmethod
     def merge(
         cls: Type["DockerExecutor"], executors: list["DockerExecutor"], num_tasks: int
     ) -> "DockerExecutor":

--- a/nemo_run/core/execution/local.py
+++ b/nemo_run/core/execution/local.py
@@ -39,6 +39,10 @@ class LocalExecutor(Executor):
     ntasks_per_node: int = 1
     nodes: int = 1
 
+    @classmethod
+    def supports_job_group(cls) -> bool:
+        return True
+
     def assign(
         self,
         exp_id: str,

--- a/nemo_run/core/execution/slurm.py
+++ b/nemo_run/core/execution/slurm.py
@@ -357,6 +357,10 @@ class SlurmExecutor(Executor):
     run_as_group: bool = field(init=False, default=False)
 
     @classmethod
+    def supports_job_group(cls) -> bool:
+        return True
+
+    @classmethod
     def merge(
         cls: Type["SlurmExecutor"], executors: list["SlurmExecutor"], num_tasks: int
     ) -> "SlurmExecutor":

--- a/nemo_run/run/job.py
+++ b/nemo_run/run/job.py
@@ -266,13 +266,16 @@ class JobGroup(ConfigurableMixin):
 
         assert len(executor_types) == 1, "All executors must be of the same type."
         executor_type = list(executor_types)[0]
-        assert executor_type in self.SUPPORTED_EXECUTORS, "Unsupported executor type."
-        if executor_type == SlurmExecutor:
+        assert executor_type.supports_job_group() or executor_type in self.SUPPORTED_EXECUTORS, (
+            f"Unsupported executor type {executor_type.__name__}. Executors opt in to JobGroup "
+            "by overriding Executor.supports_job_group()."
+        )
+        if issubclass(executor_type, SlurmExecutor):
             self._merge = True
             self.executors = SlurmExecutor.merge(
                 cast(list[SlurmExecutor], executors), num_tasks=len(self.tasks)
             )
-        elif executor_type == DockerExecutor:
+        elif issubclass(executor_type, DockerExecutor):
             self._merge = True
             self.executors = DockerExecutor.merge(
                 cast(list[DockerExecutor], executors), num_tasks=len(self.tasks)

--- a/test/run/test_job.py
+++ b/test/run/test_job.py
@@ -13,12 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
 
 import pytest
 from torchx.specs.api import AppState
 
 from nemo_run.config import Partial, Script
+from nemo_run.core.execution.base import Executor
 from nemo_run.core.execution.docker import DockerExecutor
 from nemo_run.core.execution.slurm import SlurmExecutor
 from nemo_run.run.job import Job, JobGroup
@@ -382,6 +384,61 @@ def test_job_group_init_mixed_executor_types(simple_task):
             tasks=[simple_task, simple_task],
             executors=executors,
         )
+
+
+def test_job_group_builtin_executors_opt_in():
+    # SUPPORTED_EXECUTORS and supports_job_group() must not drift apart.
+    for executor_type in JobGroup.SUPPORTED_EXECUTORS:
+        assert executor_type.supports_job_group(), executor_type.__name__
+
+
+def test_job_group_accepts_downstream_executor(simple_task):
+    @dataclass(kw_only=True)
+    class CustomExecutor(Executor):
+        @classmethod
+        def supports_job_group(cls) -> bool:
+            return True
+
+    executor = CustomExecutor(job_dir="/tmp/custom")
+    job_group = JobGroup(
+        id="test-group",
+        tasks=[simple_task, simple_task],
+        executors=executor,
+    )
+
+    assert not job_group._merge
+    assert job_group.executors == [executor, executor]
+
+
+def test_job_group_rejects_executor_without_opt_in(simple_task):
+    @dataclass(kw_only=True)
+    class UnsupportedExecutor(Executor):
+        pass
+
+    with pytest.raises(AssertionError, match="Unsupported executor type"):
+        JobGroup(
+            id="test-group",
+            tasks=[simple_task],
+            executors=UnsupportedExecutor(job_dir="/tmp/unsupported"),
+        )
+
+
+def test_job_group_slurm_subclass_keeps_group_semantics(simple_task):
+    @dataclass(kw_only=True)
+    class CustomSlurmExecutor(SlurmExecutor):
+        pass
+
+    job_group = JobGroup(
+        id="test-group",
+        tasks=[simple_task, simple_task],
+        executors=CustomSlurmExecutor(
+            account="test_account", partition="test", job_dir="/tmp/test"
+        ),
+    )
+
+    assert job_group._merge
+    assert isinstance(job_group.executors, CustomSlurmExecutor)
+    assert job_group.executors.run_as_group
 
 
 def test_job_group_properties(simple_task, docker_executor):


### PR DESCRIPTION
Closes #537.

## Problem

`JobGroup.__post_init__` gated on `executor_type in self.SUPPORTED_EXECUTORS` (`nemo_run/run/job.py:269`). That is an exact class-identity check against `[SlurmExecutor, DockerExecutor, LocalExecutor]`, so two things failed:

1. Any `Executor` defined outside nemo_run, such as nemo-skills' `RayExecutor`, could never construct a `JobGroup`. The only workarounds available downstream were mutating the class attribute or sniffing `type(executor).__name__`.
2. Any subclass of a supported executor failed too. A plain `class MySlurmExecutor(SlurmExecutor)` was rejected even though it is a `SlurmExecutor` in every meaningful sense.

## Change

@nicgupta-nvidia offered three designs on the issue and asked which would be accepted. This implements design 3, the classmethod on the base, since it is the one that needs no mutation of upstream state and shows up in IDEs and in the API docs:

- `Executor.supports_job_group()` returns `False` on the base class. `SlurmExecutor`, `DockerExecutor` and `LocalExecutor` override it to `True`.
- `JobGroup.__post_init__` gates on `executor_type.supports_job_group() or executor_type in self.SUPPORTED_EXECUTORS`. The membership clause is kept deliberately, so anyone who already extended `SUPPORTED_EXECUTORS` in the wild keeps working, and the assertion message now names the rejected class and how to opt in.
- The merge dispatch changed from `executor_type == SlurmExecutor` to `issubclass(...)`. Without that, relaxing the assertion would let a `SlurmExecutor` subclass through and then silently drop it into the `_merge = False` path, which is a worse failure than the rejection it replaces.

## What this does not do

As the issue itself notes, relaxing the assertion is necessary but not sufficient for a Ray-backed `JobGroup` to launch end to end: `JobGroup.launch` routes through `EXECUTOR_MAPPING` in `torchx_backend/schedulers/api.py`, which has no Ray entry, so `get_executor_str` still raises `KeyError`. That is a separate architectural question and is left alone here. This PR only makes the extension point real.

## Tests

Four tests in `test/run/test_job.py`:

- `test_job_group_builtin_executors_opt_in` asserts every class in `SUPPORTED_EXECUTORS` reports `supports_job_group()`, so the two lists cannot drift apart.
- `test_job_group_accepts_downstream_executor` builds a `JobGroup` from an out-of-tree `Executor` subclass that opts in, and checks it takes the no-merge path with one executor per task.
- `test_job_group_rejects_executor_without_opt_in` keeps the rejection for executors that do not opt in.
- `test_job_group_slurm_subclass_keeps_group_semantics` pins the second half of the fix: a `SlurmExecutor` subclass merges and comes back with `run_as_group` set.

Verified locally: `test/run/test_job.py` 47 passed. Reverting only the `nemo_run/` half fails 3 of the 4 new tests, so they do catch the regression. `test/run` plus `test/core/execution` match the `main` baseline exactly (24 pre-existing failures either side, from skypilot and kubeflow extras missing in my environment). `ruff format --diff` and `ruff check` clean.

@ko3n1g this one has been sitting since May 25 with no reviewer, and the reporter explicitly asked for a design verdict before sending code. If you would rather have design 1 or 2 from the issue, say so and I will swap it, the diff is small either way.