### PR TITLE
Normalize Skypilot managed job ids to int (#481)

### DIFF
--- a/nemo_run/core/execution/skypilot_jobs.py
+++ b/nemo_run/core/execution/skypilot_jobs.py
@@ -44,6 +44,20 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+def _as_job_id(job_id: Any) -> int:
+    """Coerce a Skypilot managed job id to the int this module stores in app ids.
+
+    ``sky.jobs.client.sdk.launch`` returns ``Optional[List[int]]``, so the raw value is
+    a list such as ``[1]``. App ids written before this was handled embed that list
+    form, e.g. ``cluster___task___[1]``, so parsing accepts it too.
+    """
+    if isinstance(job_id, (list, tuple)):
+        assert len(job_id) == 1, f"Expected a single Skypilot job id, got {job_id}."
+        job_id = job_id[0]
+
+    return int(str(job_id).strip("[]"))
+
+
 @dataclass(kw_only=True)
 class SkypilotJobsExecutor(Executor):
     """
@@ -148,7 +162,7 @@ class SkypilotJobsExecutor(Executor):
         app = app_id.split("___")
         cluster, task, job_id = app[0], app[1], app[2]
         assert cluster and task and job_id, f"Invalid app id for Skypilot: {app_id}"
-        return cluster, task, int(job_id)
+        return cluster, task, _as_job_id(job_id)
 
     def to_resources(self) -> Union[set["sky.Resources"], set["sky.Resources"]]:
         from sky.resources import Resources
@@ -416,9 +430,9 @@ cd /nemo_run/code
         if num_nodes:
             task.num_nodes = num_nodes
 
-        job_id, handle = stream_and_get(launch(task))
+        job_ids, handle = stream_and_get(launch(task))
 
-        return job_id, handle
+        return (_as_job_id(job_ids) if job_ids is not None else None), handle
 
     def cleanup(self, handle: str):
         import sky.jobs.client.sdk as sky_jobs

--- a/test/core/execution/test_skypilot_jobs.py
+++ b/test/core/execution/test_skypilot_jobs.py
@@ -150,6 +150,14 @@ class TestSkypilotJobsExecutor:
         assert task == "task-name"
         assert job_id == 123
 
+    def test_parse_app_legacy_list_job_id(self, mock_skypilot_imports):
+        # App ids written before #481 embed Skypilot's list job id verbatim.
+        cluster, task, job_id = SkypilotJobsExecutor.parse_app("cluster-name___task-name___[123]")
+
+        assert cluster == "cluster-name"
+        assert task == "task-name"
+        assert job_id == 123
+
     def test_parse_app_invalid(self, mock_skypilot_imports):
         # The implementation raises IndexError when the app_id format is invalid
         with pytest.raises(IndexError):
@@ -323,6 +331,24 @@ class TestSkypilotJobsExecutor:
 
         assert job_id == 123
         assert handle is mock_handle
+
+    @patch("sky.stream_and_get")
+    @patch("sky.jobs.client.sdk.launch")
+    def test_launch_normalizes_list_job_id(self, mock_launch, mock_stream_and_get, executor):
+        # sky.jobs.client.sdk.launch returns Optional[List[int]], not an int (#481).
+        mock_handle = MagicMock()
+        mock_handle.get_cluster_name.return_value = "cluster-name"
+        mock_launch.return_value = MagicMock()
+        mock_stream_and_get.return_value = ([1], mock_handle)
+
+        job_id, handle = executor.launch(MagicMock())
+
+        assert job_id == 1
+        assert handle is mock_handle
+        # The scheduler interpolates the job id straight into the app id, so it has to
+        # survive a round trip through parse_app.
+        app_id = f"{handle.get_cluster_name()}___task-name___{job_id}"
+        assert SkypilotJobsExecutor.parse_app(app_id) == ("cluster-name", "task-name", 1)
 
     def test_workdir(self, executor):
         executor.job_dir = "/path/to/job"


### PR DESCRIPTION
Closes #481.

## Root cause

SkyPilot's managed-jobs SDK returns a *list* of job ids. From `sky/jobs/client/sdk.py` in skypilot 0.12.3:

```python
def launch(...) -> server_common.RequestId[Tuple[Optional[List[int]],
                                                 Optional['backends.ResourceHandle']]]:
```

`SkypilotJobsExecutor.launch` passed that value straight through while its own annotation promised `tuple[Optional[int], ...]`, and the scheduler builds the app id by interpolation (`torchx_backend/schedulers/skypilot_jobs.py`):

```python
app_id = f"{handle.get_cluster_name()}___{task.name}___{job_id}"
```

So the app id became `cluster___task___[1]`, and the very next line, `SkypilotJobsExecutor.status(app_id=app_id)`, reached `parse_app` and died on `int('[1]')`. The job itself was already accepted by SkyPilot, so as @jesintharnold reported the managed job keeps running while nemo_run loses the handle, taking `nemo experiment status` and `nemo experiment logs` with it.

## Change

One helper, `_as_job_id`, used from both ends so the two sites cannot drift:

- `launch` unwraps the single-element list, restoring the `Optional[int]` contract its signature already claimed. A list with more than one id asserts with the value in the message rather than silently taking the first.
- `parse_app` accepts the bracketed form, so app ids already persisted in experiment metadata by an affected run remain readable instead of requiring a re-submit. `cleanup`, `logs`, `cancel` and `status` all route through `parse_app`, so they are fixed by the same change.

`SkypilotExecutor` (the non-managed path) is deliberately untouched: `sky/client/sdk.py`'s `launch` returns `Tuple[Optional[int], ...]`, so it never had this bug.

## Tests

Two in `test/core/execution/test_skypilot_jobs.py`:

- `test_launch_normalizes_list_job_id` mocks the SDK the way it actually behaves, returning `([1], handle)`, and asserts the id comes back as `1` and then survives a round trip through the same `f"..."` app-id shape the scheduler builds. The existing `test_launch` mocked `(123, handle)`, an int, which is why CI never saw this.
- `test_parse_app_legacy_list_job_id` pins the recovery path for app ids already written as `___[123]`.

Verified locally with skypilot 0.12.3 installed: 32 passed in `test/core/execution/test_skypilot_jobs.py`, and reverting only the `nemo_run/` half fails exactly the two new tests. `ruff format --diff` and `ruff check` clean.

@ko3n1g this one has been open since May 10 with no reviewer and it silently orphans running jobs, so it may be worth prioritising over the other two SkyPilot reports from the same user (#482, #483), which need real cluster access to settle.