### PR TITLE
Add ntasks to SlurmExecutor (#381)

### DIFF
--- a/nemo_run/core/execution/slurm.py
+++ b/nemo_run/core/execution/slurm.py
@@ -306,6 +306,9 @@ class SlurmExecutor(Executor):
     time: str = "00:10:00"
     nodes: int = 1
     ntasks_per_node: int = 1
+    #: Total task count for the allocation, mapped to sbatch --ntasks.
+    #: Mutually exclusive with ntasks_per_node, which is dropped when this is set.
+    ntasks: Optional[int] = None
     cpus_per_task: Optional[int] = None
     cpus_per_gpu: Optional[int] = None
     gpus_per_node: Optional[int] = None
@@ -430,6 +433,11 @@ class SlurmExecutor(Executor):
         if self.wait_time_for_group_job < 0:
             self.wait_time_for_group_job = 0
 
+        assert self.ntasks is None or not self.heterogeneous, (
+            "ntasks cannot be combined with heterogeneous=True, "
+            "size each group via resource_group instead."
+        )
+
     def info(self) -> str:
         return f"{self.__class__.__qualname__} on {self.tunnel.key}"
 
@@ -463,6 +471,10 @@ class SlurmExecutor(Executor):
             for arg in self.SRUN_ARGS
             if getattr(self, arg.replace("-", "_"), None) is not None
         }
+        if _arg_dict.get("ntasks") is not None:
+            # Same exclusion as sbatch: ntasks-per-node would cap an explicit ntasks.
+            _arg_dict.pop("ntasks-per-node", None)
+
         _arg_dict["container-mounts"] = ",".join(self.container_mounts)
         if env_vars:
             _arg_dict["container-env"] = ",".join(list(env_vars.keys()))
@@ -813,6 +825,11 @@ class SlurmBatchRequest:
         parameters = {
             k: v for k, v in args.items() if v is not None and k in SlurmExecutor.SBATCH_FLAGS
         }
+
+        # --ntasks-per-node acts as a per-node maximum when --ntasks is also present, so
+        # leaving its default of 1 in place would cap an explicit --ntasks request.
+        if parameters.get("ntasks") is not None:
+            parameters.pop("ntasks_per_node", None)
 
         # rename and reformat parameters
 

--- a/test/core/execution/test_slurm_templates.py
+++ b/test/core/execution/test_slurm_templates.py
@@ -17,6 +17,7 @@ import copy
 import os
 import re
 from pathlib import Path
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
@@ -503,6 +504,44 @@ class TestSlurmBatchRequest:
             "#SBATCH --output=/root/sample_job/sbatch_account-account.sample_job_%A_%a.out"
             in sbatch_script
         )
+
+    def test_dummy_batch_request_ntasks(
+        self,
+        dummy_slurm_request_with_artifact: tuple[SlurmBatchRequest, str],
+    ):
+        dummy_slurm_request, _ = dummy_slurm_request_with_artifact
+        dummy_slurm_request.executor.ntasks = 8
+
+        sbatch_script = dummy_slurm_request.materialize()
+        assert "#SBATCH --ntasks=8" in sbatch_script
+        assert "--ntasks-per-node" not in sbatch_script
+
+    def test_dummy_batch_request_ntasks_per_node_default(
+        self,
+        dummy_slurm_request_with_artifact: tuple[SlurmBatchRequest, str],
+    ):
+        dummy_slurm_request, _ = dummy_slurm_request_with_artifact
+
+        sbatch_script = dummy_slurm_request.materialize()
+        assert "#SBATCH --ntasks-per-node=1" in sbatch_script
+        assert "#SBATCH --ntasks=" not in sbatch_script
+
+    def test_srun_ntasks_drops_ntasks_per_node(self):
+        # sbatch and srun must apply the same exclusion, or the two drift apart.
+        executor = SlurmExecutor(account="account", tunnel=LocalTunnel(job_dir="/tmp"), ntasks=8)
+        mock_slurm = MagicMock()
+        with patch.object(
+            SlurmExecutor, "slurm", new_callable=PropertyMock, return_value=mock_slurm
+        ):
+            executor.srun("echo hi", job_name="interactive")
+
+        srun_cmd = mock_slurm.run.call_args.args[0]
+        assert "--ntasks=8" in srun_cmd
+        assert "--ntasks-per-node" not in srun_cmd
+
+    def test_ntasks_rejected_for_heterogeneous(self):
+        with pytest.raises(AssertionError, match="ntasks cannot be combined with heterogeneous"):
+            SlurmExecutor(account="account", ntasks=8, heterogeneous=True)
 
     def test_dummy_batch_additonal_params(
         self,


### PR DESCRIPTION
Closes #381.

## Why this was awkward before

`SlurmExecutor.SBATCH_FLAGS` already contains `"ntasks"`, and `SlurmBatchRequest` builds its sbatch parameters as `asdict(executor)` filtered through that list. So the flag was reachable in principle but the field never existed, which left `additional_parameters={"ntasks": 8}` as the only route, and that still emitted `--ntasks-per-node=1` alongside it from the field default. @activatedgeek's point in the issue is exactly that: the user ends up hand-deriving a per-node topology for what Slurm can size directly.

## Change

- New field `ntasks: Optional[int] = None`. Being in `SBATCH_FLAGS` already, it renders as `#SBATCH --ntasks=<n>` with no plumbing.
- When `ntasks` is set, `ntasks_per_node` is dropped from the emitted flags. Slurm treats `--ntasks-per-node` as a per-node *maximum* when `--ntasks` is also present, so leaving the default of 1 in place would cap an explicit `--ntasks=8` at one task per node. The same exclusion is applied in the interactive `srun()` helper, since `SRUN_ARGS` lists both names and would otherwise drift from the sbatch path.
- `ntasks` with `heterogeneous=True` is rejected in `__post_init__`. Het groups get their sizes from `resource_group` entries, which carry their own `ntasks_per_node`, so a top-level total would be silently overridden. A clear assertion beats that.

Default behaviour is unchanged: with `ntasks` unset, the script still renders `#SBATCH --ntasks-per-node=1` and no `--ntasks`.

## Tests

Four in `test/core/execution/test_slurm_templates.py`:

- `test_dummy_batch_request_ntasks` materializes with `ntasks=8` and asserts `--ntasks=8` is present and `--ntasks-per-node` is gone.
- `test_dummy_batch_request_ntasks_per_node_default` pins the unchanged default path.
- `test_srun_ntasks_drops_ntasks_per_node` asserts the interactive `srun` command agrees with sbatch, so the two copies of the rule cannot diverge.
- `test_ntasks_rejected_for_heterogeneous` covers the assertion.

Verified locally: 42 passed in that file, 142 passed across `test_slurm.py`, `test_slurm_templates.py`, `test_slurm_job_name.py` and `test/run/test_experiment.py`. Reverting only the `nemo_run/` half fails 3 of the 4 new tests. `ruff format --diff` and `ruff check` clean. No Slurm cluster here, so the verification is at the rendered-script level, and the flag semantics are per the sbatch and srun man pages rather than measured.

@ko3n1g one design question worth your call: I made `ntasks` win over `ntasks_per_node` because the latter is a field default rather than an explicit choice. If you would rather have `ntasks_per_node` win, or have both emitted and let Slurm reject the combination, say which and I will switch it.