### PR TITLE
Document Skypilot cluster teardown behaviour (#483)

### DIFF
--- a/docs/guides/executors/skypilot.md
+++ b/docs/guides/executors/skypilot.md
@@ -44,6 +44,8 @@ Key parameters:
 | `container_image` | Docker image for the job |
 | `cluster_name` | Optional: name of an existing cluster to reuse |
 | `setup` | Shell commands to run once on the cluster before the job |
+| `autodown` | Tear the cluster down once jobs finish. Defaults to `False`, so the cluster stays up |
+| `idle_minutes_to_autostop` | Stop (or tear down, with `autodown=True`) after this many idle minutes |
 
 ## E2E workflow
 
@@ -89,6 +91,28 @@ executor = SkypilotJobsExecutor(
     use_spot=True,
 )
 ```
+
+### Cluster lifecycle and teardown
+
+By default a `SkypilotExecutor` cluster outlives the job. `autodown` and `idle_minutes_to_autostop` are
+both off, and `cleanup()` only downloads logs, so on Kubernetes the pod stays `Running` and keeps its GPUs
+allocated until the cluster is brought down. That is SkyPilot's behaviour for an unmanaged cluster, not a
+NeMo Run defect, but the knobs are worth knowing:
+
+```python
+executor = SkypilotExecutor(
+    ...,
+    autodown=True,                  # tear down once all jobs finish
+    idle_minutes_to_autostop=10,    # or wait for 10 idle minutes first
+)
+```
+
+These map onto `sky.launch(down=..., idle_minutes_to_autostop=...)`. `autodown=True` on its own tears the
+cluster down after all jobs reach a terminal state, and combining it with `idle_minutes_to_autostop` delays
+that until the cluster has been idle for the given time. A cluster that fails during provisioning, data
+sync or setup is deliberately left up by SkyPilot for debugging, so those need `sky down <cluster>` by hand.
+To keep the cluster but stop paying for idle GPUs, set `idle_minutes_to_autostop` with `autodown=False`,
+which stops rather than deletes it.
 
 ### Package code from git
 


### PR DESCRIPTION
Addresses #483.

@jesintharnold asked whether the pod staying alive after the workload finishes is SkyPilot behaviour or a NeMo Run integration gap. It is the former, but the reason it reads as a gap is that the two fields that control it are undocumented: `SkypilotExecutor.autodown` and `SkypilotExecutor.idle_minutes_to_autostop` (`nemo_run/core/execution/skypilot.py:120-121`) are passed straight into `sky.launch` as `down=` and `idle_minutes_to_autostop=`, both default to off, and `SkypilotExecutor.cleanup()` only downloads logs. So the default is a cluster that outlives the job with its GPUs still allocated, and nothing in `docs/` said so. `grep -rn "autodown" docs/` returned nothing before this change.

This adds the two parameters to the key-parameters table and a short "Cluster lifecycle and teardown" section that covers the four cases worth knowing: `autodown=True` alone tearing down once jobs reach a terminal state, combining it with an idle timeout, `idle_minutes_to_autostop` with `autodown=False` to stop rather than delete, and the provisioning/setup-failure case that SkyPilot deliberately leaves up for debugging. The semantics are quoted from the `down` and `idle_minutes_to_autostop` docstrings in `sky/client/sdk.py` in skypilot 0.12.3, not guessed.

Docs only, no code change. If you would rather nemo_run also called `sky.down` from `cleanup()`, or defaulted `autodown` to `True`, that is a behaviour change for existing users and I would want your call before writing it.

@ko3n1g