### PR TITLE
chore: add build constraint for setuptools version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ conflicts = [
         { extra = "skypilot-all" }
     ]
 ]
+build-constraint-dependencies = ["setuptools<82"]
 override-dependencies = [
     "aiohttp>=3.14.0",                # CVE-2026-50269
     "cryptography>=46.0.6,<47",       # CVE-2026-34073

--- a/uv.lock
+++ b/uv.lock
@@ -54,6 +54,7 @@ overrides = [
     { name = "simpleeval", specifier = ">=1.0.5" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
+build-constraints = [{ name = "setuptools", specifier = "<82" }]
 
 [[package]]
 name = "absl-py"


### PR DESCRIPTION
Added a build constraint to specify that setuptools must be less than version 82. This change ensures compatibility with existing dependencies.